### PR TITLE
BaseTimeEntity 추가

### DIFF
--- a/backend/src/main/java/com/example/backend/domain/BaseTimeEntity.java
+++ b/backend/src/main/java/com/example/backend/domain/BaseTimeEntity.java
@@ -1,0 +1,28 @@
+package com.example.backend.domain;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.Column;
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+
+@Setter
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+
+    @CreatedDate
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+}


### PR DESCRIPTION
## 작업 내용
- created_at, updated_at  을 공통적으로 적용시킬 수 있는 모델을 추가합니다.
- 각 데이터가 생성될 때, 업데이트 될때 자동으로 시간이 적용됩니다.

## 이슈
- 

