### PR TITLE
API 엔드포인트 prefix 추가

### DIFF
--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -6,3 +6,6 @@ spring.security.oauth2.client.registration.github.clientSecret=${GITHUB_OAUTH_CL
 
 # flyway-migration
 spring.flyway.out-of-order=true
+
+# api convention
+server.servlet.contextPath=/api


### PR DESCRIPTION
## 작업 내용
- 모든 API 엔드포인트에 prefix 가 붙여지도록 `server.servlet.contextPath=/api` 를 추가하였습니다.

## 이슈
- [API 컨벤션](https://github.com/AlgoSolved/AlgoSolved/wiki/API-%EB%AC%B8%EC%84%9C)에 맞추기 위해 설정이 필요합니다
