### PR TITLE
[유저 페이지] - 유저 정보 & 유저 탈퇴 API

### DIFF
--- a/backend/src/main/java/com/example/backend/common/enums/ExceptionStatus.java
+++ b/backend/src/main/java/com/example/backend/common/enums/ExceptionStatus.java
@@ -2,16 +2,17 @@ package com.example.backend.common.enums;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+
 import org.springframework.http.HttpStatus;
 
 @Getter
 @AllArgsConstructor
 public enum ExceptionStatus {
-  NOT_FOUND("4040", "데이터를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
-  USER_NOT_FOUND("4041", "유저를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
-  USERNAME_MISMATCH("4042", "입력한 유저네임이 일치하지 않습니다.", HttpStatus.BAD_REQUEST);
+    NOT_FOUND("4040", "데이터를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    USER_NOT_FOUND("4041", "유저를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    USERNAME_MISMATCH("4042", "입력한 유저네임이 일치하지 않습니다.", HttpStatus.BAD_REQUEST);
 
-  private final String code;
-  private final String message;
-  private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+    private final HttpStatus httpStatus;
 }

--- a/backend/src/main/java/com/example/backend/common/enums/ExceptionStatus.java
+++ b/backend/src/main/java/com/example/backend/common/enums/ExceptionStatus.java
@@ -2,16 +2,16 @@ package com.example.backend.common.enums;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-
 import org.springframework.http.HttpStatus;
 
 @Getter
 @AllArgsConstructor
 public enum ExceptionStatus {
-    NOT_FOUND("4040", "데이터를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
-    USER_NOT_FOUND("4041", "유저를 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
+  NOT_FOUND("4040", "데이터를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+  USER_NOT_FOUND("4041", "유저를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+  USERNAME_MISMATCH("4042", "입력한 유저네임이 일치하지 않습니다.", HttpStatus.BAD_REQUEST);
 
-    private final String code;
-    private final String message;
-    private final HttpStatus httpStatus;
+  private final String code;
+  private final String message;
+  private final HttpStatus httpStatus;
 }

--- a/backend/src/main/java/com/example/backend/common/exceptions/BadRequestException.java
+++ b/backend/src/main/java/com/example/backend/common/exceptions/BadRequestException.java
@@ -1,0 +1,12 @@
+package com.example.backend.common.exceptions;
+
+import com.example.backend.common.enums.ExceptionStatus;
+
+public class BadRequestException extends RuntimeException {
+
+  private final ExceptionStatus exceptionStatus;
+
+  public BadRequestException(ExceptionStatus exceptionStatus) {
+    this.exceptionStatus = exceptionStatus;
+  }
+}

--- a/backend/src/main/java/com/example/backend/common/exceptions/BadRequestException.java
+++ b/backend/src/main/java/com/example/backend/common/exceptions/BadRequestException.java
@@ -4,9 +4,9 @@ import com.example.backend.common.enums.ExceptionStatus;
 
 public class BadRequestException extends RuntimeException {
 
-  private final ExceptionStatus exceptionStatus;
+    private final ExceptionStatus exceptionStatus;
 
-  public BadRequestException(ExceptionStatus exceptionStatus) {
-    this.exceptionStatus = exceptionStatus;
-  }
+    public BadRequestException(ExceptionStatus exceptionStatus) {
+        this.exceptionStatus = exceptionStatus;
+    }
 }

--- a/backend/src/main/java/com/example/backend/common/exceptions/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/example/backend/common/exceptions/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package com.example.backend.common.exceptions;
 
 import com.example.backend.common.enums.ExceptionStatus;
 import com.example.backend.common.response.BaseResponse;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -9,26 +10,26 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 @ControllerAdvice
 public class GlobalExceptionHandler {
 
-  @ExceptionHandler(NotFoundException.class)
-  public ResponseEntity<BaseResponse> handleNotFoundException(ExceptionStatus exceptionStatus) {
-    BaseResponse exceptionResponse =
-        BaseResponse.builder()
-            .code(exceptionStatus.getCode())
-            .message(exceptionStatus.getMessage())
-            .build();
+    @ExceptionHandler(NotFoundException.class)
+    public ResponseEntity<BaseResponse> handleNotFoundException(ExceptionStatus exceptionStatus) {
+        BaseResponse exceptionResponse =
+                BaseResponse.builder()
+                        .code(exceptionStatus.getCode())
+                        .message(exceptionStatus.getMessage())
+                        .build();
 
-    return new ResponseEntity(exceptionResponse, exceptionStatus.getHttpStatus());
-  }
+        return new ResponseEntity(exceptionResponse, exceptionStatus.getHttpStatus());
+    }
 
-  @ExceptionHandler(BadRequestException.class)
-  public ResponseEntity<BaseResponse> handleUsernameMismatchException(
-      ExceptionStatus exceptionStatus) {
-    BaseResponse exceptionResponse =
-        BaseResponse.builder()
-            .code(exceptionStatus.getCode())
-            .message(exceptionStatus.getMessage())
-            .build();
+    @ExceptionHandler(BadRequestException.class)
+    public ResponseEntity<BaseResponse> handleUsernameMismatchException(
+            ExceptionStatus exceptionStatus) {
+        BaseResponse exceptionResponse =
+                BaseResponse.builder()
+                        .code(exceptionStatus.getCode())
+                        .message(exceptionStatus.getMessage())
+                        .build();
 
-    return new ResponseEntity<>(exceptionResponse, exceptionStatus.getHttpStatus());
-  }
+        return new ResponseEntity<>(exceptionResponse, exceptionStatus.getHttpStatus());
+    }
 }

--- a/backend/src/main/java/com/example/backend/common/exceptions/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/example/backend/common/exceptions/GlobalExceptionHandler.java
@@ -2,7 +2,6 @@ package com.example.backend.common.exceptions;
 
 import com.example.backend.common.enums.ExceptionStatus;
 import com.example.backend.common.response.BaseResponse;
-
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -10,14 +9,26 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 @ControllerAdvice
 public class GlobalExceptionHandler {
 
-    @ExceptionHandler(NotFoundException.class)
-    public ResponseEntity<BaseResponse> handleNotFoundException(ExceptionStatus exceptionStatus) {
-        BaseResponse exceptionResponse =
-                BaseResponse.builder()
-                        .code(exceptionStatus.getCode())
-                        .message(exceptionStatus.getMessage())
-                        .build();
+  @ExceptionHandler(NotFoundException.class)
+  public ResponseEntity<BaseResponse> handleNotFoundException(ExceptionStatus exceptionStatus) {
+    BaseResponse exceptionResponse =
+        BaseResponse.builder()
+            .code(exceptionStatus.getCode())
+            .message(exceptionStatus.getMessage())
+            .build();
 
-        return new ResponseEntity(exceptionResponse, exceptionStatus.getHttpStatus());
-    }
+    return new ResponseEntity(exceptionResponse, exceptionStatus.getHttpStatus());
+  }
+
+  @ExceptionHandler(BadRequestException.class)
+  public ResponseEntity<BaseResponse> handleUsernameMismatchException(
+      ExceptionStatus exceptionStatus) {
+    BaseResponse exceptionResponse =
+        BaseResponse.builder()
+            .code(exceptionStatus.getCode())
+            .message(exceptionStatus.getMessage())
+            .build();
+
+    return new ResponseEntity<>(exceptionResponse, exceptionStatus.getHttpStatus());
+  }
 }

--- a/backend/src/main/java/com/example/backend/github/domain/GithubRepository.java
+++ b/backend/src/main/java/com/example/backend/github/domain/GithubRepository.java
@@ -3,43 +3,51 @@ package com.example.backend.github.domain;
 import com.example.backend.common.BaseTimeEntity;
 import com.example.backend.solution.domain.Solution;
 import com.example.backend.user.domain.User;
-
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import javax.persistence.CascadeType;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.OneToMany;
+import javax.persistence.OneToOne;
+import javax.persistence.Table;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
-
-import javax.persistence.*;
+import org.springframework.stereotype.Repository;
 
 @Setter
 @Getter
 @Entity
 @NoArgsConstructor
+@Repository
 @Table(name = "github_repositories")
 public class GithubRepository extends BaseTimeEntity {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
 
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id")
-    private User user;
+  @OneToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "user_id")
+  private User user;
 
-    private String repo;
+  private String repo;
 
-    @OneToMany(mappedBy = "githubRepository")
-    private List<Solution> solutions = new ArrayList<>();
+  @OneToMany(mappedBy = "githubRepository", cascade = CascadeType.REMOVE)
+  private List<Solution> solutions = new ArrayList<>();
 
-    @Builder
-    public GithubRepository(User user, String repo) {
-        this.user = user;
-        this.repo = repo;
-        this.setCreatedAt(LocalDateTime.now());
-        this.setUpdatedAt(LocalDateTime.now());
-    }
+  @Builder
+  public GithubRepository(User user, String repo) {
+    this.user = user;
+    this.repo = repo;
+    this.setCreatedAt(LocalDateTime.now());
+    this.setUpdatedAt(LocalDateTime.now());
+  }
 }

--- a/backend/src/main/java/com/example/backend/github/domain/GithubRepository.java
+++ b/backend/src/main/java/com/example/backend/github/domain/GithubRepository.java
@@ -3,9 +3,18 @@ package com.example.backend.github.domain;
 import com.example.backend.common.BaseTimeEntity;
 import com.example.backend.solution.domain.Solution;
 import com.example.backend.user.domain.User;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import org.springframework.stereotype.Repository;
+
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+
 import javax.persistence.CascadeType;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -16,11 +25,6 @@ import javax.persistence.JoinColumn;
 import javax.persistence.OneToMany;
 import javax.persistence.OneToOne;
 import javax.persistence.Table;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
-import org.springframework.stereotype.Repository;
 
 @Setter
 @Getter
@@ -30,24 +34,24 @@ import org.springframework.stereotype.Repository;
 @Table(name = "github_repositories")
 public class GithubRepository extends BaseTimeEntity {
 
-  @Id
-  @GeneratedValue(strategy = GenerationType.IDENTITY)
-  private Long id;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
 
-  @OneToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "user_id")
-  private User user;
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
 
-  private String repo;
+    private String repo;
 
-  @OneToMany(mappedBy = "githubRepository", cascade = CascadeType.REMOVE)
-  private List<Solution> solutions = new ArrayList<>();
+    @OneToMany(mappedBy = "githubRepository", cascade = CascadeType.REMOVE)
+    private List<Solution> solutions = new ArrayList<>();
 
-  @Builder
-  public GithubRepository(User user, String repo) {
-    this.user = user;
-    this.repo = repo;
-    this.setCreatedAt(LocalDateTime.now());
-    this.setUpdatedAt(LocalDateTime.now());
-  }
+    @Builder
+    public GithubRepository(User user, String repo) {
+        this.user = user;
+        this.repo = repo;
+        this.setCreatedAt(LocalDateTime.now());
+        this.setUpdatedAt(LocalDateTime.now());
+    }
 }

--- a/backend/src/main/java/com/example/backend/user/controller/UserController.java
+++ b/backend/src/main/java/com/example/backend/user/controller/UserController.java
@@ -1,5 +1,7 @@
 package com.example.backend.user.controller;
 
+import com.example.backend.common.enums.ExceptionStatus;
+import com.example.backend.common.exceptions.NotFoundException;
 import com.example.backend.common.response.BaseResponse;
 import com.example.backend.user.dto.UserDTO;
 import com.example.backend.user.response.UserStatus;
@@ -7,6 +9,7 @@ import com.example.backend.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -28,5 +31,18 @@ public class UserController {
             UserStatus.SUCCESS.getCode(),
             UserStatus.SUCCESS.getMessage(),
             userDTO), HttpStatus.OK);
+  }
+
+  @DeleteMapping("/{username}")
+  public ResponseEntity<BaseResponse<String>> deleteUser(@PathVariable String username) {
+    if (userService.deleteUser(username)) {
+      return new ResponseEntity(
+          BaseResponse.success(
+              UserStatus.SUCCESS.getCode(),
+              UserStatus.SUCCESS.getMessage()),
+          HttpStatus.OK);
+    } else {
+      throw new NotFoundException(ExceptionStatus.USER_NOT_FOUND);
+    }
   }
 }

--- a/backend/src/main/java/com/example/backend/user/controller/UserController.java
+++ b/backend/src/main/java/com/example/backend/user/controller/UserController.java
@@ -6,7 +6,9 @@ import com.example.backend.common.response.BaseResponse;
 import com.example.backend.user.dto.UserDTO;
 import com.example.backend.user.response.UserStatus;
 import com.example.backend.user.service.UserService;
+
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -20,29 +22,27 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/v1/user")
 public class UserController {
 
-  private final UserService userService;
+    private final UserService userService;
 
-  @GetMapping("/{username}")
-  public ResponseEntity<BaseResponse<UserDTO>> getUserInfo(@PathVariable String username) {
-    UserDTO userDTO = userService.getUserByUsername(username);
+    @GetMapping("/{username}")
+    public ResponseEntity<BaseResponse<UserDTO>> getUserInfo(@PathVariable String username) {
+        UserDTO userDTO = userService.getUserByUsername(username);
 
-    return new ResponseEntity(
-        BaseResponse.success(
-            UserStatus.SUCCESS.getCode(),
-            UserStatus.SUCCESS.getMessage(),
-            userDTO), HttpStatus.OK);
-  }
-
-  @DeleteMapping("/{username}")
-  public ResponseEntity<BaseResponse<String>> deleteUser(@PathVariable String username) {
-    if (userService.deleteUser(username)) {
-      return new ResponseEntity(
-          BaseResponse.success(
-              UserStatus.SUCCESS.getCode(),
-              UserStatus.SUCCESS.getMessage()),
-          HttpStatus.OK);
-    } else {
-      throw new NotFoundException(ExceptionStatus.USER_NOT_FOUND);
+        return new ResponseEntity(
+                BaseResponse.success(
+                        UserStatus.SUCCESS.getCode(), UserStatus.SUCCESS.getMessage(), userDTO),
+                HttpStatus.OK);
     }
-  }
+
+    @DeleteMapping("/{username}")
+    public ResponseEntity<BaseResponse<String>> deleteUser(@PathVariable String username) {
+        if (userService.deleteUser(username)) {
+            return new ResponseEntity(
+                    BaseResponse.success(
+                            UserStatus.SUCCESS.getCode(), UserStatus.SUCCESS.getMessage()),
+                    HttpStatus.OK);
+        } else {
+            throw new NotFoundException(ExceptionStatus.USER_NOT_FOUND);
+        }
+    }
 }

--- a/backend/src/main/java/com/example/backend/user/controller/UserController.java
+++ b/backend/src/main/java/com/example/backend/user/controller/UserController.java
@@ -6,9 +6,7 @@ import com.example.backend.common.response.BaseResponse;
 import com.example.backend.user.dto.UserDTO;
 import com.example.backend.user.response.UserStatus;
 import com.example.backend.user.service.UserService;
-
 import lombok.RequiredArgsConstructor;
-
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -22,27 +20,27 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/v1/user")
 public class UserController {
 
-    private final UserService userService;
+  private final UserService userService;
 
-    @GetMapping("/{username}")
-    public ResponseEntity<BaseResponse<UserDTO>> getUserInfo(@PathVariable String username) {
-        UserDTO userDTO = userService.getUserByUsername(username);
+  @GetMapping("/{id}")
+  public ResponseEntity<BaseResponse<UserDTO>> getUserInfo(@PathVariable("id") Long id) {
+    UserDTO userDTO = userService.getUserInfo(id);
 
-        return new ResponseEntity(
-                BaseResponse.success(
-                        UserStatus.SUCCESS.getCode(), UserStatus.SUCCESS.getMessage(), userDTO),
-                HttpStatus.OK);
+    return new ResponseEntity(
+        BaseResponse.success(
+            UserStatus.SUCCESS.getCode(), UserStatus.SUCCESS.getMessage(), userDTO),
+        HttpStatus.OK);
+  }
+
+  @DeleteMapping("/{id}")
+  public ResponseEntity<BaseResponse<String>> deleteUser(@PathVariable("id") Long id) {
+    if (userService.deleteUser(id)) {
+      return new ResponseEntity(
+          BaseResponse.success(
+              UserStatus.SUCCESS.getCode(), UserStatus.SUCCESS.getMessage()),
+          HttpStatus.OK);
+    } else {
+      throw new NotFoundException(ExceptionStatus.USER_NOT_FOUND);
     }
-
-    @DeleteMapping("/{username}")
-    public ResponseEntity<BaseResponse<String>> deleteUser(@PathVariable String username) {
-        if (userService.deleteUser(username)) {
-            return new ResponseEntity(
-                    BaseResponse.success(
-                            UserStatus.SUCCESS.getCode(), UserStatus.SUCCESS.getMessage()),
-                    HttpStatus.OK);
-        } else {
-            throw new NotFoundException(ExceptionStatus.USER_NOT_FOUND);
-        }
-    }
+  }
 }

--- a/backend/src/main/java/com/example/backend/user/controller/UserController.java
+++ b/backend/src/main/java/com/example/backend/user/controller/UserController.java
@@ -3,7 +3,7 @@ package com.example.backend.user.controller;
 import com.example.backend.common.enums.ExceptionStatus;
 import com.example.backend.common.exceptions.NotFoundException;
 import com.example.backend.common.response.BaseResponse;
-import com.example.backend.user.dto.UserDTO;
+import com.example.backend.user.dto.UserDTO.Profile;
 import com.example.backend.user.response.UserStatus;
 import com.example.backend.user.service.UserService;
 import lombok.RequiredArgsConstructor;
@@ -23,12 +23,12 @@ public class UserController {
   private final UserService userService;
 
   @GetMapping("/{id}")
-  public ResponseEntity<BaseResponse<UserDTO>> getUserInfo(@PathVariable("id") Long id) {
-    UserDTO userDTO = userService.getUserInfo(id);
+  public ResponseEntity<BaseResponse<Profile>> getUserInfo(@PathVariable("id") Long id) {
+    Profile userInfo = userService.getUserProfile(id);
 
     return new ResponseEntity(
         BaseResponse.success(
-            UserStatus.SUCCESS.getCode(), UserStatus.SUCCESS.getMessage(), userDTO),
+            UserStatus.SUCCESS.getCode(), UserStatus.SUCCESS.getMessage(), userInfo),
         HttpStatus.OK);
   }
 

--- a/backend/src/main/java/com/example/backend/user/controller/UserController.java
+++ b/backend/src/main/java/com/example/backend/user/controller/UserController.java
@@ -4,7 +4,9 @@ import com.example.backend.common.response.BaseResponse;
 import com.example.backend.user.dto.UserDTO.Profile;
 import com.example.backend.user.response.UserStatus;
 import com.example.backend.user.service.UserService;
+
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -19,26 +21,25 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/v1/user")
 public class UserController {
 
-  private final UserService userService;
+    private final UserService userService;
 
-  @GetMapping("/{id}")
-  public ResponseEntity<BaseResponse<Profile>> getUserInfo(@PathVariable("id") Long id) {
-    Profile userInfo = userService.getUserProfile(id);
+    @GetMapping("/{id}")
+    public ResponseEntity<BaseResponse<Profile>> getUserInfo(@PathVariable("id") Long id) {
+        Profile userInfo = userService.getUserProfile(id);
 
-    return new ResponseEntity(
-        BaseResponse.success(
-            UserStatus.SUCCESS.getCode(), UserStatus.SUCCESS.getMessage(), userInfo),
-        HttpStatus.OK);
-  }
+        return new ResponseEntity(
+                BaseResponse.success(
+                        UserStatus.SUCCESS.getCode(), UserStatus.SUCCESS.getMessage(), userInfo),
+                HttpStatus.OK);
+    }
 
-  @DeleteMapping("/{id}")
-  public ResponseEntity<BaseResponse<String>> deleteUser(@PathVariable("id") Long id,
-      @RequestParam String inputUsername) {
-    userService.deleteUser(id, inputUsername);
+    @DeleteMapping("/{id}")
+    public ResponseEntity<BaseResponse<String>> deleteUser(
+            @PathVariable("id") Long id, @RequestParam String inputUsername) {
+        userService.deleteUser(id, inputUsername);
 
-    return new ResponseEntity(
-        BaseResponse.success(
-            UserStatus.SUCCESS.getCode(), UserStatus.SUCCESS.getMessage()),
-        HttpStatus.OK);
-  }
+        return new ResponseEntity(
+                BaseResponse.success(UserStatus.SUCCESS.getCode(), UserStatus.SUCCESS.getMessage()),
+                HttpStatus.OK);
+    }
 }

--- a/backend/src/main/java/com/example/backend/user/controller/UserController.java
+++ b/backend/src/main/java/com/example/backend/user/controller/UserController.java
@@ -1,0 +1,32 @@
+package com.example.backend.user.controller;
+
+import com.example.backend.common.response.BaseResponse;
+import com.example.backend.user.dto.UserDTO;
+import com.example.backend.user.response.UserStatus;
+import com.example.backend.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/user")
+public class UserController {
+
+  private final UserService userService;
+
+  @GetMapping("/{username}")
+  public ResponseEntity<BaseResponse<UserDTO>> getUserInfo(@PathVariable String username) {
+    UserDTO userDTO = userService.getUserByUsername(username);
+
+    return new ResponseEntity(
+        BaseResponse.success(
+            UserStatus.SUCCESS.getCode(),
+            UserStatus.SUCCESS.getMessage(),
+            userDTO), HttpStatus.OK);
+  }
+}

--- a/backend/src/main/java/com/example/backend/user/controller/UserController.java
+++ b/backend/src/main/java/com/example/backend/user/controller/UserController.java
@@ -1,7 +1,5 @@
 package com.example.backend.user.controller;
 
-import com.example.backend.common.enums.ExceptionStatus;
-import com.example.backend.common.exceptions.NotFoundException;
 import com.example.backend.common.response.BaseResponse;
 import com.example.backend.user.dto.UserDTO.Profile;
 import com.example.backend.user.response.UserStatus;
@@ -13,6 +11,7 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -33,14 +32,13 @@ public class UserController {
   }
 
   @DeleteMapping("/{id}")
-  public ResponseEntity<BaseResponse<String>> deleteUser(@PathVariable("id") Long id) {
-    if (userService.deleteUser(id)) {
-      return new ResponseEntity(
-          BaseResponse.success(
-              UserStatus.SUCCESS.getCode(), UserStatus.SUCCESS.getMessage()),
-          HttpStatus.OK);
-    } else {
-      throw new NotFoundException(ExceptionStatus.USER_NOT_FOUND);
-    }
+  public ResponseEntity<BaseResponse<String>> deleteUser(@PathVariable("id") Long id,
+      @RequestParam String inputUsername) {
+    userService.deleteUser(id, inputUsername);
+
+    return new ResponseEntity(
+        BaseResponse.success(
+            UserStatus.SUCCESS.getCode(), UserStatus.SUCCESS.getMessage()),
+        HttpStatus.OK);
   }
 }

--- a/backend/src/main/java/com/example/backend/user/dto/UserDTO.java
+++ b/backend/src/main/java/com/example/backend/user/dto/UserDTO.java
@@ -1,23 +1,25 @@
 package com.example.backend.user.dto;
 
 import com.example.backend.user.domain.User;
-
 import lombok.Builder;
 import lombok.Getter;
 
-@Getter
-@Builder
 public class UserDTO {
+
+  @Getter
+  @Builder
+  public static class Profile {
 
     private String username;
     private Long solutionCount;
     private String githubLink;
 
-    public static UserDTO mapToDTO(User user, Long solutionCount) {
-        return UserDTO.builder()
-                .username(user.getUsername())
-                .solutionCount(solutionCount)
-                .githubLink(user.getGithubUrl())
-                .build();
+    public static Profile mapToDTO(User user, Long solutionCount) {
+      return Profile.builder()
+          .username(user.getUsername())
+          .solutionCount(solutionCount)
+          .githubLink(user.getGithubUrl())
+          .build();
     }
+  }
 }

--- a/backend/src/main/java/com/example/backend/user/dto/UserDTO.java
+++ b/backend/src/main/java/com/example/backend/user/dto/UserDTO.java
@@ -1,25 +1,26 @@
 package com.example.backend.user.dto;
 
 import com.example.backend.user.domain.User;
+
 import lombok.Builder;
 import lombok.Getter;
 
 public class UserDTO {
 
-  @Getter
-  @Builder
-  public static class Profile {
+    @Getter
+    @Builder
+    public static class Profile {
 
-    private String username;
-    private Long solutionCount;
-    private String githubLink;
+        private String username;
+        private Long solutionCount;
+        private String githubLink;
 
-    public static Profile mapToDTO(User user, Long solutionCount) {
-      return Profile.builder()
-          .username(user.getUsername())
-          .solutionCount(solutionCount)
-          .githubLink(user.getGithubUrl())
-          .build();
+        public static Profile mapToDTO(User user, Long solutionCount) {
+            return Profile.builder()
+                    .username(user.getUsername())
+                    .solutionCount(solutionCount)
+                    .githubLink(user.getGithubUrl())
+                    .build();
+        }
     }
-  }
 }

--- a/backend/src/main/java/com/example/backend/user/dto/UserDTO.java
+++ b/backend/src/main/java/com/example/backend/user/dto/UserDTO.java
@@ -1,6 +1,7 @@
 package com.example.backend.user.dto;
 
 import com.example.backend.user.domain.User;
+
 import lombok.Builder;
 import lombok.Getter;
 
@@ -8,15 +9,15 @@ import lombok.Getter;
 @Builder
 public class UserDTO {
 
-  private String username;
-  private Long solutionCount;
-  private String githubLink;
+    private String username;
+    private Long solutionCount;
+    private String githubLink;
 
-  public static UserDTO mapToDTO(User user, Long solutionCount) {
-    return UserDTO.builder()
-        .username(user.getUsername())
-        .solutionCount(solutionCount)
-        .githubLink(user.getGithubUrl())
-        .build();
-  }
+    public static UserDTO mapToDTO(User user, Long solutionCount) {
+        return UserDTO.builder()
+                .username(user.getUsername())
+                .solutionCount(solutionCount)
+                .githubLink(user.getGithubUrl())
+                .build();
+    }
 }

--- a/backend/src/main/java/com/example/backend/user/dto/UserDTO.java
+++ b/backend/src/main/java/com/example/backend/user/dto/UserDTO.java
@@ -1,0 +1,22 @@
+package com.example.backend.user.dto;
+
+import com.example.backend.user.domain.User;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class UserDTO {
+
+  private String username;
+  private Long solutionCount;
+  private String githubLink;
+
+  public static UserDTO mapToDTO(User user, Long solutionCount) {
+    return UserDTO.builder()
+        .username(user.getUsername())
+        .solutionCount(solutionCount)
+        .githubLink(user.getGithubUrl())
+        .build();
+  }
+}

--- a/backend/src/main/java/com/example/backend/user/repository/UserRepository.java
+++ b/backend/src/main/java/com/example/backend/user/repository/UserRepository.java
@@ -1,11 +1,11 @@
 package com.example.backend.user.repository;
 
 import com.example.backend.user.domain.User;
-
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRepository extends JpaRepository<User, Long> {
-    Boolean existsByUsername(String username);
 
-    User findByUsername(String username);
+  Boolean existsByUsername(String username);
+
+  User findByUsername(String username);
 }

--- a/backend/src/main/java/com/example/backend/user/repository/UserRepository.java
+++ b/backend/src/main/java/com/example/backend/user/repository/UserRepository.java
@@ -1,14 +1,16 @@
 package com.example.backend.user.repository;
 
 import com.example.backend.user.domain.User;
-import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
-  Boolean existsByUsername(String username);
+    Boolean existsByUsername(String username);
 
-  User findByUsername(String username);
+    User findByUsername(String username);
 
-  Optional<User> findById(Long id);
+    Optional<User> findById(Long id);
 }

--- a/backend/src/main/java/com/example/backend/user/repository/UserRepository.java
+++ b/backend/src/main/java/com/example/backend/user/repository/UserRepository.java
@@ -1,12 +1,14 @@
 package com.example.backend.user.repository;
 
 import com.example.backend.user.domain.User;
-
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
-    Boolean existsByUsername(String username);
+  Boolean existsByUsername(String username);
 
-    User findByUsername(String username);
+  User findByUsername(String username);
+
+  Optional<User> findById(Long id);
 }

--- a/backend/src/main/java/com/example/backend/user/repository/UserRepository.java
+++ b/backend/src/main/java/com/example/backend/user/repository/UserRepository.java
@@ -1,11 +1,12 @@
 package com.example.backend.user.repository;
 
 import com.example.backend.user.domain.User;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
-  Boolean existsByUsername(String username);
+    Boolean existsByUsername(String username);
 
-  User findByUsername(String username);
+    User findByUsername(String username);
 }

--- a/backend/src/main/java/com/example/backend/user/response/UserStatus.java
+++ b/backend/src/main/java/com/example/backend/user/response/UserStatus.java
@@ -6,7 +6,8 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum UserStatus {
-    SUCCESS("2000", "요청에 성공하였습니다.");
-    private final String code;
-    private final String message;
+  SUCCESS("2000", "요청에 성공하였습니다.");
+
+  private final String code;
+  private final String message;
 }

--- a/backend/src/main/java/com/example/backend/user/response/UserStatus.java
+++ b/backend/src/main/java/com/example/backend/user/response/UserStatus.java
@@ -6,8 +6,8 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum UserStatus {
-  SUCCESS("2000", "요청에 성공하였습니다.");
+    SUCCESS("2000", "요청에 성공하였습니다.");
 
-  private final String code;
-  private final String message;
+    private final String code;
+    private final String message;
 }

--- a/backend/src/main/java/com/example/backend/user/response/UserStatus.java
+++ b/backend/src/main/java/com/example/backend/user/response/UserStatus.java
@@ -1,0 +1,13 @@
+package com.example.backend.user.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum UserStatus {
+  SUCCESS("2000", "요청에 성공하였습니다.");
+
+  private final String code;
+  private final String message;
+}

--- a/backend/src/main/java/com/example/backend/user/response/UserStatus.java
+++ b/backend/src/main/java/com/example/backend/user/response/UserStatus.java
@@ -6,8 +6,7 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum UserStatus {
-  SUCCESS("2000", "요청에 성공하였습니다.");
-
-  private final String code;
-  private final String message;
+    SUCCESS("2000", "요청에 성공하였습니다.");
+    private final String code;
+    private final String message;
 }

--- a/backend/src/main/java/com/example/backend/user/service/UserService.java
+++ b/backend/src/main/java/com/example/backend/user/service/UserService.java
@@ -7,45 +7,50 @@ import com.example.backend.github.domain.GithubRepository;
 import com.example.backend.user.domain.User;
 import com.example.backend.user.dto.UserDTO.Profile;
 import com.example.backend.user.repository.UserRepository;
-import javax.transaction.Transactional;
+
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class UserService {
 
-  private final UserRepository userRepository;
+    private final UserRepository userRepository;
 
-  public Profile getUserProfile(Long id) {
-    User user = userRepository
-        .findById(id)
-        .orElseThrow(() -> new NotFoundException(ExceptionStatus.NOT_FOUND));
+    public Profile getUserProfile(Long id) {
+        User user =
+                userRepository
+                        .findById(id)
+                        .orElseThrow(() -> new NotFoundException(ExceptionStatus.NOT_FOUND));
 
-    return Profile.mapToDTO(user, getSolutionCount(user.getGithubRepository()));
-  }
-
-  public Long getSolutionCount(GithubRepository githubRepository) {
-    if (githubRepository == null) {
-      return 0L;
+        return Profile.mapToDTO(user, getSolutionCount(user.getGithubRepository()));
     }
-    return githubRepository.getSolutions().stream().count();
-  }
 
-  @Transactional
-  public void deleteUser(Long id, String inputUsername) {
-    User user = userRepository.findById(id)
-        .orElseThrow(() -> new NotFoundException(ExceptionStatus.NOT_FOUND));
-
-    if (verifyUsername(user.getUsername(), inputUsername)) {
-      userRepository.delete(user);
-    } else {
-      throw new BadRequestException(ExceptionStatus.USERNAME_MISMATCH);
+    public Long getSolutionCount(GithubRepository githubRepository) {
+        if (githubRepository == null) {
+            return 0L;
+        }
+        return githubRepository.getSolutions().stream().count();
     }
-  }
 
-  private boolean verifyUsername(String storedUsername, String inputUsername) {
-    return storedUsername.equals(inputUsername);
-  }
+    @Transactional
+    public void deleteUser(Long id, String inputUsername) {
+        User user =
+                userRepository
+                        .findById(id)
+                        .orElseThrow(() -> new NotFoundException(ExceptionStatus.NOT_FOUND));
+
+        if (verifyUsername(user.getUsername(), inputUsername)) {
+            userRepository.delete(user);
+        } else {
+            throw new BadRequestException(ExceptionStatus.USERNAME_MISMATCH);
+        }
+    }
+
+    private boolean verifyUsername(String storedUsername, String inputUsername) {
+        return storedUsername.equals(inputUsername);
+    }
 }
-

--- a/backend/src/main/java/com/example/backend/user/service/UserService.java
+++ b/backend/src/main/java/com/example/backend/user/service/UserService.java
@@ -6,39 +6,35 @@ import com.example.backend.github.domain.GithubRepository;
 import com.example.backend.user.domain.User;
 import com.example.backend.user.dto.UserDTO;
 import com.example.backend.user.repository.UserRepository;
-
-import lombok.RequiredArgsConstructor;
-
-import org.springframework.stereotype.Service;
-
 import javax.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class UserService {
 
-    private final UserRepository userRepository;
+  private final UserRepository userRepository;
 
-    public UserDTO getUserByUsername(String username) {
-        User user = userRepository.findByUsername(username);
+  public UserDTO getUserInfo(Long id) {
+    User user = userRepository
+        .findById(id)
+        .orElseThrow(() -> new NotFoundException(ExceptionStatus.NOT_FOUND));
 
-        if (user == null) {
-            throw new NotFoundException(ExceptionStatus.USER_NOT_FOUND);
-        }
-        return UserDTO.mapToDTO(user, getSolutionCount(user.getGithubRepository()));
-    }
+    return UserDTO.mapToDTO(user, getSolutionCount(user.getGithubRepository()));
+  }
 
-    public Long getSolutionCount(GithubRepository githubRepository) {
-        return githubRepository.getSolutions().stream().count();
-    }
+  public Long getSolutionCount(GithubRepository githubRepository) {
+    return githubRepository.getSolutions().stream().count();
+  }
 
-    @Transactional
-    public boolean deleteUser(String username) {
-        User user = userRepository.findByUsername(username);
-        if (user != null) {
-            userRepository.delete(user);
-            return true;
-        }
-        return false;
-    }
+  @Transactional
+  public boolean deleteUser(Long id) {
+    return userRepository.findById(id)
+        .map(user -> {
+          userRepository.delete(user);
+          return true;
+        })
+        .orElseThrow(() -> new NotFoundException(ExceptionStatus.NOT_FOUND));
+  }
 }

--- a/backend/src/main/java/com/example/backend/user/service/UserService.java
+++ b/backend/src/main/java/com/example/backend/user/service/UserService.java
@@ -4,7 +4,7 @@ import com.example.backend.common.enums.ExceptionStatus;
 import com.example.backend.common.exceptions.NotFoundException;
 import com.example.backend.github.domain.GithubRepository;
 import com.example.backend.user.domain.User;
-import com.example.backend.user.dto.UserDTO;
+import com.example.backend.user.dto.UserDTO.Profile;
 import com.example.backend.user.repository.UserRepository;
 import javax.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -16,12 +16,12 @@ public class UserService {
 
   private final UserRepository userRepository;
 
-  public UserDTO getUserInfo(Long id) {
+  public Profile getUserProfile(Long id) {
     User user = userRepository
         .findById(id)
         .orElseThrow(() -> new NotFoundException(ExceptionStatus.NOT_FOUND));
 
-    return UserDTO.mapToDTO(user, getSolutionCount(user.getGithubRepository()));
+    return Profile.mapToDTO(user, getSolutionCount(user.getGithubRepository()));
   }
 
   public Long getSolutionCount(GithubRepository githubRepository) {

--- a/backend/src/main/java/com/example/backend/user/service/UserService.java
+++ b/backend/src/main/java/com/example/backend/user/service/UserService.java
@@ -26,6 +26,9 @@ public class UserService {
   }
 
   public Long getSolutionCount(GithubRepository githubRepository) {
+    if (githubRepository == null) {
+      return 0L;
+    }
     return githubRepository.getSolutions().stream().count();
   }
 

--- a/backend/src/main/java/com/example/backend/user/service/UserService.java
+++ b/backend/src/main/java/com/example/backend/user/service/UserService.java
@@ -6,6 +6,7 @@ import com.example.backend.github.domain.GithubRepository;
 import com.example.backend.user.domain.User;
 import com.example.backend.user.dto.UserDTO;
 import com.example.backend.user.repository.UserRepository;
+import javax.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -21,11 +22,21 @@ public class UserService {
     if (user == null) {
       throw new NotFoundException(ExceptionStatus.USER_NOT_FOUND);
     }
-
     return UserDTO.mapToDTO(user, getSolutionCount(user.getGithubRepository()));
   }
 
   public Long getSolutionCount(GithubRepository githubRepository) {
     return githubRepository.getSolutions().stream().count();
   }
+
+  @Transactional
+  public boolean deleteUser(String username) {
+    User user = userRepository.findByUsername(username);
+    if (user != null) {
+      userRepository.delete(user);
+      return true;
+    }
+    return false;
+  }
 }
+

--- a/backend/src/main/java/com/example/backend/user/service/UserService.java
+++ b/backend/src/main/java/com/example/backend/user/service/UserService.java
@@ -6,37 +6,39 @@ import com.example.backend.github.domain.GithubRepository;
 import com.example.backend.user.domain.User;
 import com.example.backend.user.dto.UserDTO;
 import com.example.backend.user.repository.UserRepository;
-import javax.transaction.Transactional;
+
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class UserService {
 
-  private final UserRepository userRepository;
+    private final UserRepository userRepository;
 
-  public UserDTO getUserByUsername(String username) {
-    User user = userRepository.findByUsername(username);
+    public UserDTO getUserByUsername(String username) {
+        User user = userRepository.findByUsername(username);
 
-    if (user == null) {
-      throw new NotFoundException(ExceptionStatus.USER_NOT_FOUND);
+        if (user == null) {
+            throw new NotFoundException(ExceptionStatus.USER_NOT_FOUND);
+        }
+        return UserDTO.mapToDTO(user, getSolutionCount(user.getGithubRepository()));
     }
-    return UserDTO.mapToDTO(user, getSolutionCount(user.getGithubRepository()));
-  }
 
-  public Long getSolutionCount(GithubRepository githubRepository) {
-    return githubRepository.getSolutions().stream().count();
-  }
-
-  @Transactional
-  public boolean deleteUser(String username) {
-    User user = userRepository.findByUsername(username);
-    if (user != null) {
-      userRepository.delete(user);
-      return true;
+    public Long getSolutionCount(GithubRepository githubRepository) {
+        return githubRepository.getSolutions().stream().count();
     }
-    return false;
-  }
+
+    @Transactional
+    public boolean deleteUser(String username) {
+        User user = userRepository.findByUsername(username);
+        if (user != null) {
+            userRepository.delete(user);
+            return true;
+        }
+        return false;
+    }
 }
-

--- a/backend/src/main/java/com/example/backend/user/service/UserService.java
+++ b/backend/src/main/java/com/example/backend/user/service/UserService.java
@@ -1,6 +1,7 @@
 package com.example.backend.user.service;
 
 import com.example.backend.common.enums.ExceptionStatus;
+import com.example.backend.common.exceptions.BadRequestException;
 import com.example.backend.common.exceptions.NotFoundException;
 import com.example.backend.github.domain.GithubRepository;
 import com.example.backend.user.domain.User;
@@ -29,12 +30,19 @@ public class UserService {
   }
 
   @Transactional
-  public boolean deleteUser(Long id) {
-    return userRepository.findById(id)
-        .map(user -> {
-          userRepository.delete(user);
-          return true;
-        })
+  public void deleteUser(Long id, String inputUsername) {
+    User user = userRepository.findById(id)
         .orElseThrow(() -> new NotFoundException(ExceptionStatus.NOT_FOUND));
+
+    if (verifyUsername(user.getUsername(), inputUsername)) {
+      userRepository.delete(user);
+    } else {
+      throw new BadRequestException(ExceptionStatus.USERNAME_MISMATCH);
+    }
+  }
+
+  private boolean verifyUsername(String storedUsername, String inputUsername) {
+    return storedUsername.equals(inputUsername);
   }
 }
+

--- a/backend/src/main/java/com/example/backend/user/service/UserService.java
+++ b/backend/src/main/java/com/example/backend/user/service/UserService.java
@@ -1,0 +1,31 @@
+package com.example.backend.user.service;
+
+import com.example.backend.common.enums.ExceptionStatus;
+import com.example.backend.common.exceptions.NotFoundException;
+import com.example.backend.github.domain.GithubRepository;
+import com.example.backend.user.domain.User;
+import com.example.backend.user.dto.UserDTO;
+import com.example.backend.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+  private final UserRepository userRepository;
+
+  public UserDTO getUserByUsername(String username) {
+    User user = userRepository.findByUsername(username);
+
+    if (user == null) {
+      throw new NotFoundException(ExceptionStatus.USER_NOT_FOUND);
+    }
+
+    return UserDTO.mapToDTO(user, getSolutionCount(user.getGithubRepository()));
+  }
+
+  public Long getSolutionCount(GithubRepository githubRepository) {
+    return githubRepository.getSolutions().stream().count();
+  }
+}

--- a/backend/src/test/java/com/example/backend/user/UserControllerTest.java
+++ b/backend/src/test/java/com/example/backend/user/UserControllerTest.java
@@ -11,7 +11,7 @@ import com.example.backend.user.controller.UserController;
 import com.example.backend.user.dto.UserDTO;
 import com.example.backend.user.service.UserService;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.util.Map;
+
 import org.instancio.Instancio;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -22,52 +22,53 @@ import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.util.Map;
+
 @WebMvcTest(UserController.class)
 public class UserControllerTest {
 
-  @Autowired
-  private MockMvc mockMvc;
+    @Autowired private MockMvc mockMvc;
 
-  @MockBean
-  private UserService userService;
+    @MockBean private UserService userService;
 
-  @Test
-  @DisplayName("v1/users/{username} 성공 테스트")
-  @WithMockUser(username = "jake", roles = "USER")
-  void 유저_정보_성공() throws Exception {
-    UserDTO userDTO = Instancio.create(UserDTO.class);
-    when(userService.getUserByUsername("jake")).thenReturn(userDTO);
+    @Test
+    @DisplayName("v1/users/{username} 성공 테스트")
+    @WithMockUser(username = "jake", roles = "USER")
+    void 유저_정보_성공() throws Exception {
+        UserDTO userDTO = Instancio.create(UserDTO.class);
+        when(userService.getUserByUsername("jake")).thenReturn(userDTO);
 
-    ObjectMapper objectMapper = new ObjectMapper();
-    Map<String, Object> resultMap = objectMapper.convertValue(userDTO, Map.class);
+        ObjectMapper objectMapper = new ObjectMapper();
+        Map<String, Object> resultMap = objectMapper.convertValue(userDTO, Map.class);
 
-    mockMvc.perform(get("/v1/user/{username}", "jake"))
-        .andExpect(status().isOk())
-        .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
-        .andExpect(
-            content()
-                .json(
-                    """
+        mockMvc.perform(get("/v1/user/{username}", "jake"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(
+                        content()
+                                .json(
+                                        """
                         {
                             "code": "2000",
                             "message": "요청에 성공하였습니다.",
                             "data": %s
                         }
                         """
-                        .formatted(resultMap)));
-  }
+                                                .formatted(resultMap)));
+    }
 
-  @Test
-  @DisplayName("v1/users/{username} 실패 테스트")
-  @WithMockUser(username = "nonexistentuser", roles = "USER")
-  void 유저_정보_실패() throws Exception {
+    @Test
+    @DisplayName("v1/users/{username} 실패 테스트")
+    @WithMockUser(username = "nonexistentuser", roles = "USER")
+    void 유저_정보_실패() throws Exception {
 
-    String nonexistentUsername = "nonexistentuser";
-    when(userService.getUserByUsername(nonexistentUsername))
-        .thenThrow(new NotFoundException(ExceptionStatus.USER_NOT_FOUND));
+        String nonexistentUsername = "nonexistentuser";
+        when(userService.getUserByUsername(nonexistentUsername))
+                .thenThrow(new NotFoundException(ExceptionStatus.USER_NOT_FOUND));
 
-    mockMvc.perform(get("/v1/users/{username}", nonexistentUsername)
-            .contentType(MediaType.APPLICATION_JSON))
-        .andExpect(status().isNotFound());
-  }
+        mockMvc.perform(
+                        get("/v1/users/{username}", nonexistentUsername)
+                                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound());
+    }
 }

--- a/backend/src/test/java/com/example/backend/user/UserControllerTest.java
+++ b/backend/src/test/java/com/example/backend/user/UserControllerTest.java
@@ -1,6 +1,7 @@
 package com.example.backend.user;
 
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -32,9 +33,9 @@ public class UserControllerTest {
   private UserService userService;
 
   @Test
-  @DisplayName("v1/users/{id} 성공 테스트")
+  @DisplayName("id에 해당하는 유저가 존재하는 경우 관련된 정보를 반환한다.")
   @WithMockUser(username = "jake", roles = "USER")
-  void 유저_정보_성공() throws Exception {
+  void 유저_정보_반환_성공() throws Exception {
     UserDTO.Profile userProfile = Instancio.create(UserDTO.Profile.class);
     when(userService.getUserProfile(1L)).thenReturn(userProfile);
 
@@ -58,9 +59,9 @@ public class UserControllerTest {
   }
 
   @Test
-  @DisplayName("v1/users/{id} 실패 테스트")
+  @DisplayName("id에 해당하는 유저가 존재하지 않은 경우 에러를 반환한다.")
   @WithMockUser(username = "jake", roles = "USER")
-  void 유저_정보_실패() throws Exception {
+  void 유저_정보_반환_실패() throws Exception {
     when(userService.getUserProfile(1L))
         .thenThrow(new NotFoundException(ExceptionStatus.NOT_FOUND));
 
@@ -68,5 +69,26 @@ public class UserControllerTest {
             get("/v1/users/{1}", 1)
                 .contentType(MediaType.APPLICATION_JSON))
         .andExpect(status().isNotFound());
+  }
+
+  @Test
+  @DisplayName("사용자가 입력한 유저네임이 일치한 경우 true를 반환한다.")
+  @WithMockUser(username = "jake", roles = "USER")
+  void 유저_탈퇴_성공() throws Exception {
+    mockMvc.perform(delete("/v1/user/{id}", 1)
+            .param("inputUsername", "jake"))
+        .andExpect(status().isOk())
+        .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+        .andExpect(
+            content()
+                .json(
+                    """
+                        {
+                            "code": "2000",
+                            "message": "요청에 성공하였습니다."
+                        }
+                        """
+                ));
+
   }
 }

--- a/backend/src/test/java/com/example/backend/user/UserControllerTest.java
+++ b/backend/src/test/java/com/example/backend/user/UserControllerTest.java
@@ -1,0 +1,73 @@
+package com.example.backend.user;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.example.backend.common.enums.ExceptionStatus;
+import com.example.backend.common.exceptions.NotFoundException;
+import com.example.backend.user.controller.UserController;
+import com.example.backend.user.dto.UserDTO;
+import com.example.backend.user.service.UserService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Map;
+import org.instancio.Instancio;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(UserController.class)
+public class UserControllerTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @MockBean
+  private UserService userService;
+
+  @Test
+  @DisplayName("v1/users/{username} 성공 테스트")
+  @WithMockUser(username = "jake", roles = "USER")
+  void 유저_정보_성공() throws Exception {
+    UserDTO userDTO = Instancio.create(UserDTO.class);
+    when(userService.getUserByUsername("jake")).thenReturn(userDTO);
+
+    ObjectMapper objectMapper = new ObjectMapper();
+    Map<String, Object> resultMap = objectMapper.convertValue(userDTO, Map.class);
+
+    mockMvc.perform(get("/v1/user/{username}", "jake"))
+        .andExpect(status().isOk())
+        .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+        .andExpect(
+            content()
+                .json(
+                    """
+                        {
+                            "code": "2000",
+                            "message": "요청에 성공하였습니다.",
+                            "data": %s
+                        }
+                        """
+                        .formatted(resultMap)));
+  }
+
+  @Test
+  @DisplayName("v1/users/{username} 실패 테스트")
+  @WithMockUser(username = "nonexistentuser", roles = "USER")
+  void 유저_정보_실패() throws Exception {
+
+    String nonexistentUsername = "nonexistentuser";
+    when(userService.getUserByUsername(nonexistentUsername))
+        .thenThrow(new NotFoundException(ExceptionStatus.USER_NOT_FOUND));
+
+    mockMvc.perform(get("/v1/users/{username}", nonexistentUsername)
+            .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isNotFound());
+  }
+}

--- a/backend/src/test/java/com/example/backend/user/UserControllerTest.java
+++ b/backend/src/test/java/com/example/backend/user/UserControllerTest.java
@@ -12,7 +12,7 @@ import com.example.backend.user.controller.UserController;
 import com.example.backend.user.dto.UserDTO;
 import com.example.backend.user.service.UserService;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.util.Map;
+
 import org.instancio.Instancio;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -23,72 +23,67 @@ import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.util.Map;
+
 @WebMvcTest(UserController.class)
 public class UserControllerTest {
 
-  @Autowired
-  private MockMvc mockMvc;
+    @Autowired private MockMvc mockMvc;
 
-  @MockBean
-  private UserService userService;
+    @MockBean private UserService userService;
 
-  @Test
-  @DisplayName("id에 해당하는 유저가 존재하는 경우 관련된 정보를 반환한다.")
-  @WithMockUser(username = "jake", roles = "USER")
-  void 유저_정보_반환_성공() throws Exception {
-    UserDTO.Profile userProfile = Instancio.create(UserDTO.Profile.class);
-    when(userService.getUserProfile(1L)).thenReturn(userProfile);
+    @Test
+    @DisplayName("id에 해당하는 유저가 존재하는 경우 관련된 정보를 반환한다.")
+    @WithMockUser(username = "jake", roles = "USER")
+    void 유저_정보_반환_성공() throws Exception {
+        UserDTO.Profile userProfile = Instancio.create(UserDTO.Profile.class);
+        when(userService.getUserProfile(1L)).thenReturn(userProfile);
 
-    ObjectMapper objectMapper = new ObjectMapper();
-    Map<String, Object> resultMap = objectMapper.convertValue(userProfile, Map.class);
+        ObjectMapper objectMapper = new ObjectMapper();
+        Map<String, Object> resultMap = objectMapper.convertValue(userProfile, Map.class);
 
-    mockMvc.perform(get("/v1/user/{id}", 1))
-        .andExpect(status().isOk())
-        .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
-        .andExpect(
-            content()
-                .json(
-                    """
+        mockMvc.perform(get("/v1/user/{id}", 1))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(
+                        content()
+                                .json(
+                                        """
                         {
                             "code": "2000",
                             "message": "요청에 성공하였습니다.",
                             "data": %s
                         }
                         """
-                        .formatted(resultMap)));
-  }
+                                                .formatted(resultMap)));
+    }
 
-  @Test
-  @DisplayName("id에 해당하는 유저가 존재하지 않은 경우 에러를 반환한다.")
-  @WithMockUser(username = "jake", roles = "USER")
-  void 유저_정보_반환_실패() throws Exception {
-    when(userService.getUserProfile(1L))
-        .thenThrow(new NotFoundException(ExceptionStatus.NOT_FOUND));
+    @Test
+    @DisplayName("id에 해당하는 유저가 존재하지 않은 경우 에러를 반환한다.")
+    @WithMockUser(username = "jake", roles = "USER")
+    void 유저_정보_반환_실패() throws Exception {
+        when(userService.getUserProfile(1L))
+                .thenThrow(new NotFoundException(ExceptionStatus.NOT_FOUND));
 
-    mockMvc.perform(
-            get("/v1/users/{1}", 1)
-                .contentType(MediaType.APPLICATION_JSON))
-        .andExpect(status().isNotFound());
-  }
+        mockMvc.perform(get("/v1/users/{1}", 1).contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound());
+    }
 
-  @Test
-  @DisplayName("사용자가 입력한 유저네임이 일치한 경우 true를 반환한다.")
-  @WithMockUser(username = "jake", roles = "USER")
-  void 유저_탈퇴_성공() throws Exception {
-    mockMvc.perform(delete("/v1/user/{id}", 1)
-            .param("inputUsername", "jake"))
-        .andExpect(status().isOk())
-        .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
-        .andExpect(
-            content()
-                .json(
-                    """
+    @Test
+    @DisplayName("사용자가 입력한 유저네임이 일치한 경우 true를 반환한다.")
+    @WithMockUser(username = "jake", roles = "USER")
+    void 유저_탈퇴_성공() throws Exception {
+        mockMvc.perform(delete("/v1/user/{id}", 1).param("inputUsername", "jake"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(
+                        content()
+                                .json(
+                                        """
                         {
                             "code": "2000",
                             "message": "요청에 성공하였습니다."
                         }
-                        """
-                ));
-
-  }
+                        """));
+    }
 }

--- a/backend/src/test/java/com/example/backend/user/UserControllerTest.java
+++ b/backend/src/test/java/com/example/backend/user/UserControllerTest.java
@@ -11,7 +11,7 @@ import com.example.backend.user.controller.UserController;
 import com.example.backend.user.dto.UserDTO;
 import com.example.backend.user.service.UserService;
 import com.fasterxml.jackson.databind.ObjectMapper;
-
+import java.util.Map;
 import org.instancio.Instancio;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -22,53 +22,51 @@ import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
-import java.util.Map;
-
 @WebMvcTest(UserController.class)
 public class UserControllerTest {
 
-    @Autowired private MockMvc mockMvc;
+  @Autowired
+  private MockMvc mockMvc;
 
-    @MockBean private UserService userService;
+  @MockBean
+  private UserService userService;
 
-    @Test
-    @DisplayName("v1/users/{username} 성공 테스트")
-    @WithMockUser(username = "jake", roles = "USER")
-    void 유저_정보_성공() throws Exception {
-        UserDTO userDTO = Instancio.create(UserDTO.class);
-        when(userService.getUserByUsername("jake")).thenReturn(userDTO);
+  @Test
+  @DisplayName("v1/users/{id} 성공 테스트")
+  @WithMockUser(username = "jake", roles = "USER")
+  void 유저_정보_성공() throws Exception {
+    UserDTO.Profile userProfile = Instancio.create(UserDTO.Profile.class);
+    when(userService.getUserProfile(1L)).thenReturn(userProfile);
 
-        ObjectMapper objectMapper = new ObjectMapper();
-        Map<String, Object> resultMap = objectMapper.convertValue(userDTO, Map.class);
+    ObjectMapper objectMapper = new ObjectMapper();
+    Map<String, Object> resultMap = objectMapper.convertValue(userProfile, Map.class);
 
-        mockMvc.perform(get("/v1/user/{username}", "jake"))
-                .andExpect(status().isOk())
-                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
-                .andExpect(
-                        content()
-                                .json(
-                                        """
+    mockMvc.perform(get("/v1/user/{id}", 1))
+        .andExpect(status().isOk())
+        .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+        .andExpect(
+            content()
+                .json(
+                    """
                         {
                             "code": "2000",
                             "message": "요청에 성공하였습니다.",
                             "data": %s
                         }
                         """
-                                                .formatted(resultMap)));
-    }
+                        .formatted(resultMap)));
+  }
 
-    @Test
-    @DisplayName("v1/users/{username} 실패 테스트")
-    @WithMockUser(username = "nonexistentuser", roles = "USER")
-    void 유저_정보_실패() throws Exception {
+  @Test
+  @DisplayName("v1/users/{id} 실패 테스트")
+  @WithMockUser(username = "jake", roles = "USER")
+  void 유저_정보_실패() throws Exception {
+    when(userService.getUserProfile(1L))
+        .thenThrow(new NotFoundException(ExceptionStatus.NOT_FOUND));
 
-        String nonexistentUsername = "nonexistentuser";
-        when(userService.getUserByUsername(nonexistentUsername))
-                .thenThrow(new NotFoundException(ExceptionStatus.USER_NOT_FOUND));
-
-        mockMvc.perform(
-                        get("/v1/users/{username}", nonexistentUsername)
-                                .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isNotFound());
-    }
+    mockMvc.perform(
+            get("/v1/users/{1}", 1)
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isNotFound());
+  }
 }

--- a/backend/src/test/java/com/example/backend/user/UserServiceTest.java
+++ b/backend/src/test/java/com/example/backend/user/UserServiceTest.java
@@ -1,0 +1,64 @@
+package com.example.backend.user;
+
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+import com.example.backend.common.exceptions.BadRequestException;
+import com.example.backend.user.domain.User;
+import com.example.backend.user.dto.UserDTO;
+import com.example.backend.user.repository.UserRepository;
+import com.example.backend.user.service.UserService;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class UserServiceTest {
+
+  @InjectMocks
+  private UserService userService;
+  @Mock
+  private UserRepository userRepository;
+
+  User user;
+
+  @BeforeEach
+  public void setUp() {
+    user =
+        User.builder()
+            .username("jake")
+            .name("jake")
+            .profileImageUrl("image-url")
+            .githubUrl("github-url")
+            .build();
+  }
+
+  @Test
+  @DisplayName("id에 해당하는 유저 정보를 반환한다.")
+  void 유저_프로필_반환_성공() {
+    when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+
+    UserDTO.Profile userProfile = userService.getUserProfile(1L);
+
+    assertEquals("jake", userProfile.getUsername());
+    assertEquals("github-url", userProfile.getGithubLink());
+    assertEquals(0L, userProfile.getSolutionCount());
+  }
+
+  @Test
+  @DisplayName("사용자가 입력한 유저네임이 불일치한 경우 에러를 반환한다.")
+  void 유저_탈퇴_실패() {
+    when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+
+    assertThrows(BadRequestException.class, () ->
+        userService.deleteUser(1L, "incorrectUsername"));
+  }
+}
+

--- a/backend/src/test/java/com/example/backend/user/UserServiceTest.java
+++ b/backend/src/test/java/com/example/backend/user/UserServiceTest.java
@@ -1,6 +1,5 @@
 package com.example.backend.user;
 
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
@@ -10,7 +9,7 @@ import com.example.backend.user.domain.User;
 import com.example.backend.user.dto.UserDTO;
 import com.example.backend.user.repository.UserRepository;
 import com.example.backend.user.service.UserService;
-import java.util.Optional;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -19,46 +18,45 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.Optional;
+
 @ExtendWith(MockitoExtension.class)
 public class UserServiceTest {
 
-  @InjectMocks
-  private UserService userService;
-  @Mock
-  private UserRepository userRepository;
+    @InjectMocks private UserService userService;
+    @Mock private UserRepository userRepository;
 
-  User user;
+    User user;
 
-  @BeforeEach
-  public void setUp() {
-    user =
-        User.builder()
-            .username("jake")
-            .name("jake")
-            .profileImageUrl("image-url")
-            .githubUrl("github-url")
-            .build();
-  }
+    @BeforeEach
+    public void setUp() {
+        user =
+                User.builder()
+                        .username("jake")
+                        .name("jake")
+                        .profileImageUrl("image-url")
+                        .githubUrl("github-url")
+                        .build();
+    }
 
-  @Test
-  @DisplayName("id에 해당하는 유저 정보를 반환한다.")
-  void 유저_프로필_반환_성공() {
-    when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+    @Test
+    @DisplayName("id에 해당하는 유저 정보를 반환한다.")
+    void 유저_프로필_반환_성공() {
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
 
-    UserDTO.Profile userProfile = userService.getUserProfile(1L);
+        UserDTO.Profile userProfile = userService.getUserProfile(1L);
 
-    assertEquals("jake", userProfile.getUsername());
-    assertEquals("github-url", userProfile.getGithubLink());
-    assertEquals(0L, userProfile.getSolutionCount());
-  }
+        assertEquals("jake", userProfile.getUsername());
+        assertEquals("github-url", userProfile.getGithubLink());
+        assertEquals(0L, userProfile.getSolutionCount());
+    }
 
-  @Test
-  @DisplayName("사용자가 입력한 유저네임이 불일치한 경우 에러를 반환한다.")
-  void 유저_탈퇴_실패() {
-    when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+    @Test
+    @DisplayName("사용자가 입력한 유저네임이 불일치한 경우 에러를 반환한다.")
+    void 유저_탈퇴_실패() {
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
 
-    assertThrows(BadRequestException.class, () ->
-        userService.deleteUser(1L, "incorrectUsername"));
-  }
+        assertThrows(
+                BadRequestException.class, () -> userService.deleteUser(1L, "incorrectUsername"));
+    }
 }
-


### PR DESCRIPTION
## 작업 내용
- 유저 이름 / 공유한 문제 풀이 수 / 깃허브 링크를 반환하는 API 추가 
  - UserDTO 구조 변경(Inner Class 사용)
- 유저 탈퇴 API 추가
  -  깃허브 링크와 솔루션 매핑에 따른 연관관계 삭제(FK)를 위한 깃허브 도메인 내 REMOVE 타입 추가
  -  유저네임을 통한 회원 탈퇴 검증 단계 추가 
     - 불일치 시 예외 처리 추가(common/exception)
- 유저 컨트롤러 및 서비스 테스트 코드 작성 


## 기타 사항
  -  추후 유저 탈퇴 버튼 클릭 시, 모달창과 함께 유저네임을 재입력하고 이를 검증한 후 메인 페이지로 리다이렉트 하는 프론트 작업 필요 
  -  유저 탈퇴 검증 과정에서 유저네임 불일치 시 던진 예외 클래스에 대한 위치 논의 필요
  (사실상 용도로는 전역에 두는 의미가 없는 것 같습니다. 의견 부탁드려요.)
  -  깃허브 소셜 로그인 관련 정보는 찾았으나, 시큐리티 부분에서 미흡한 이해로 논의 필요
     (Ref. [참고1](https://spring.io/guides/tutorials/spring-boot-oauth2#_social_login_logout), [참고2](https://stackoverflow.com/questions/50354976/how-to-logout-oauth2-client-in-spring))
 