### PR TITLE
깃헙 연결 해제 로직 추가

### DIFF
--- a/backend/src/main/java/com/example/backend/common/response/BaseResponse.java
+++ b/backend/src/main/java/com/example/backend/common/response/BaseResponse.java
@@ -22,4 +22,12 @@ public class BaseResponse<T> {
     public static <T> BaseResponse<Object> success(String code, String message, T data) {
         return BaseResponse.builder().code(code).message(message).data(data).build();
     }
+
+    public static BaseResponse<Object> failure(String code, String message) {
+        return BaseResponse.builder().code(code).message(message).data(null).build();
+    }
+
+    public static <T> BaseResponse<Object> failure(String code, String message, T data) {
+        return BaseResponse.builder().code(code).message(message).data(data).build();
+    }
 }

--- a/backend/src/main/java/com/example/backend/user/controller/UserController.java
+++ b/backend/src/main/java/com/example/backend/user/controller/UserController.java
@@ -1,5 +1,6 @@
 package com.example.backend.user.controller;
 
+import com.example.backend.common.enums.ExceptionStatus;
 import com.example.backend.common.response.BaseResponse;
 import com.example.backend.user.dto.UserDTO.Profile;
 import com.example.backend.user.response.UserStatus;
@@ -34,12 +35,19 @@ public class UserController {
     }
 
     @DeleteMapping("/{id}")
-    public ResponseEntity<BaseResponse<String>> deleteUser(
-            @PathVariable("id") Long id, @RequestParam String inputUsername) {
-        userService.deleteUser(id, inputUsername);
-
+    public ResponseEntity<BaseResponse<Boolean>> deleteUser(
+            @PathVariable("id") Long userId, @RequestParam String inputUsername) {
+        if (!userService.verifyUsername(userId, inputUsername)) {
+            return new ResponseEntity(
+                    BaseResponse.failure(
+                            ExceptionStatus.USERNAME_MISMATCH.getCode(),
+                            ExceptionStatus.USERNAME_MISMATCH.getMessage()),
+                    HttpStatus.BAD_REQUEST);
+        }
+        boolean result = userService.deleteUser(userId);
         return new ResponseEntity(
-                BaseResponse.success(UserStatus.SUCCESS.getCode(), UserStatus.SUCCESS.getMessage()),
+                BaseResponse.success(
+                        UserStatus.SUCCESS.getCode(), UserStatus.SUCCESS.getMessage(), result),
                 HttpStatus.OK);
     }
 }

--- a/backend/src/main/java/com/example/backend/user/domain/User.java
+++ b/backend/src/main/java/com/example/backend/user/domain/User.java
@@ -48,15 +48,24 @@ public class User extends BaseTimeEntity {
     @Column(name = "github_url")
     private String githubUrl;
 
+    @Column(name = "access_token")
+    private String accessToken;
+
     @Column(name = "deleted_at")
     private LocalDateTime deletedAt;
 
     @Builder
-    public User(String username, String name, String profileImageUrl, String githubUrl) {
+    public User(
+            String username,
+            String name,
+            String profileImageUrl,
+            String githubUrl,
+            String accessToken) {
         this.username = username;
         this.name = name;
         this.profileImageUrl = profileImageUrl;
         this.githubUrl = githubUrl;
+        this.accessToken = accessToken;
         this.setCreatedAt(LocalDateTime.now());
         this.setUpdatedAt(LocalDateTime.now());
     }

--- a/backend/src/main/java/com/example/backend/user/service/OAuthService.java
+++ b/backend/src/main/java/com/example/backend/user/service/OAuthService.java
@@ -22,18 +22,15 @@ public class OAuthService implements OAuth2UserService<OAuth2UserRequest, OAuth2
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
         try {
             DefaultOAuth2UserService service = new DefaultOAuth2UserService();
+            String accessToken = userRequest.getAccessToken().getTokenValue();
             OAuth2User oAuth2User = service.loadUser(userRequest); // OAuth 서비스에서 가져온 유저 정보 담김
 
             String username = oAuth2User.getAttribute("login");
 
-            if (isExistUser(username)) {
-                return oAuth2User;
+            if (!isExistUser(username)) {
+                User user = createUserFromOAuth(accessToken, oAuth2User);
+                userRepository.save(user);
             }
-
-            User user = createUserFromOAuth(oAuth2User);
-
-            userRepository.save(user);
-
             return oAuth2User;
         } catch (OAuth2AuthenticationException e) {
             throw new RuntimeException("[Error] Failed to load OAuth2 user" + e.getMessage(), e);
@@ -45,12 +42,13 @@ public class OAuthService implements OAuth2UserService<OAuth2UserRequest, OAuth2
         return userRepository.existsByUsername(username);
     }
 
-    private User createUserFromOAuth(OAuth2User oAuth2User) {
+    private User createUserFromOAuth(String accessToken, OAuth2User oAuth2User) {
         return User.builder()
                 .username(oAuth2User.getAttribute("login"))
                 .name(oAuth2User.getAttribute("name"))
                 .profileImageUrl(oAuth2User.getAttribute("avatar_url"))
                 .githubUrl(oAuth2User.getAttribute("html_url"))
+                .accessToken(accessToken)
                 .build();
     }
 }

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -15,6 +15,13 @@ spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
 # server
 server.port=8080
 
+# github
+github.app.id=${github.app.id}
+github.app.installationId=${github.app.installationId}
+github.app.privateKey=${github.app.privateKey}
+github.oauth.client.id=${github.oauth.client.id}
+github.oauth.client.secret=${github.oauth.client.secret}
+
 # security
 spring.security.oauth2.client.registration.github.clientId=${github.oauth.client.id}
 spring.security.oauth2.client.registration.github.clientSecret=${github.oauth.client.secret}
@@ -24,8 +31,3 @@ spring.flyway.out-of-order=true
 
 # api convention
 server.servlet.contextPath=/api
-
-# github
-github.app.id=${github.app.id}
-github.app.installationId=${github.app.installationId}
-github.app.privateKey=${github.app.privateKey}

--- a/backend/src/main/resources/db/migration/V2__add_access_token_to_users.sql
+++ b/backend/src/main/resources/db/migration/V2__add_access_token_to_users.sql
@@ -1,0 +1,1 @@
+ALTER TABLE users ADD COLUMN access_token VARCHAR(255);

--- a/backend/src/test/java/com/example/backend/github/SyncWithGithubServiceTest.java
+++ b/backend/src/test/java/com/example/backend/github/SyncWithGithubServiceTest.java
@@ -39,6 +39,7 @@ public class SyncWithGithubServiceTest {
                         .name("uchan")
                         .profileImageUrl("image-url")
                         .githubUrl("github-url")
+                        .accessToken("accesstoken")
                         .build();
     }
 
@@ -114,6 +115,7 @@ public class SyncWithGithubServiceTest {
                             .name("uchan")
                             .profileImageUrl("image-url")
                             .githubUrl("github-url")
+                            .accessToken("accesstoken")
                             .build();
             GithubRepository githubRepository =
                     GithubRepository.builder().user(user).repo("repo").build();
@@ -137,6 +139,7 @@ public class SyncWithGithubServiceTest {
                             .name("uchan")
                             .profileImageUrl("image-url")
                             .githubUrl("github-url")
+                            .accessToken("accesstoken")
                             .build();
             GithubRepository githubRepository =
                     GithubRepository.builder().user(user).repo("repo").build();

--- a/backend/src/test/java/com/example/backend/solution/SolutionRepositoryTest.java
+++ b/backend/src/test/java/com/example/backend/solution/SolutionRepositoryTest.java
@@ -37,6 +37,7 @@ public class SolutionRepositoryTest {
                         .name("uchan")
                         .profileImageUrl("image-url")
                         .githubUrl("github-url")
+                        .accessToken("accesstoken")
                         .build();
         userRepository.save(user);
         GithubRepository githubRepository =

--- a/backend/src/test/java/com/example/backend/solution/SolutionServiceTest.java
+++ b/backend/src/test/java/com/example/backend/solution/SolutionServiceTest.java
@@ -52,6 +52,7 @@ public class SolutionServiceTest {
                             .name("uchan")
                             .profileImageUrl("image-url")
                             .githubUrl("github-url")
+                            .accessToken("accesstoken")
                             .build();
             githubRepository = GithubRepository.builder().user(user).repo("repo").build();
             problem =

--- a/backend/src/test/resources/application.properties
+++ b/backend/src/test/resources/application.properties
@@ -15,3 +15,5 @@ spring.flyway.out-of-order=true
 github.app.id=test-1
 github.app.installationId=123
 github.app.privateKey=test-private-key
+github.oauth.client.id=test
+github.oauth.client.secret=test


### PR DESCRIPTION
## 작업 내용
- 깃헙 연결 해제 로직 추가했습니다
- 깃헙 연동 해제하려면 유저의 AccessToken 을 알아야돼서 users 테이블에 access_token 칼럼 추가하였습니다
  - 이와 관련하여 기존 유저를 빌드하는 부분들 수정하였습니다
- 코드는 셀프리뷰 참고해주세요

## 이슈
- 회원 탈퇴 시 깃헙연결 해제하도록 합니다

## 체크 리스트
- Merge/배포 후에 체크해야할 사항이 있으면 적어주세요.
