### PR TITLE
깃허브 연동 시 소스코드 길이 제한 추가

### DIFF
--- a/backend/src/main/java/com/example/backend/github/service/SyncWithGithubService.java
+++ b/backend/src/main/java/com/example/backend/github/service/SyncWithGithubService.java
@@ -6,10 +6,13 @@ import com.example.backend.lib.GithubClient;
 import com.example.backend.solution.common.enums.LanguageType;
 import com.example.backend.user.domain.User;
 import com.example.backend.user.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.stereotype.Service;
+
 import java.util.ArrayList;
 import java.util.List;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
@@ -58,7 +61,7 @@ public class SyncWithGithubService {
             for (String file : solutionFiles) {
                 String sourceCode = githubClient.getContent(repo, file);
                 if (sourceCode != null) {
-                    result.add(new String[]{file, sourceCode});
+                    result.add(new String[] {file, sourceCode});
                 }
             }
 

--- a/backend/src/main/java/com/example/backend/github/service/SyncWithGithubService.java
+++ b/backend/src/main/java/com/example/backend/github/service/SyncWithGithubService.java
@@ -6,17 +6,15 @@ import com.example.backend.lib.GithubClient;
 import com.example.backend.solution.common.enums.LanguageType;
 import com.example.backend.user.domain.User;
 import com.example.backend.user.repository.UserRepository;
-
-import lombok.RequiredArgsConstructor;
-
-import org.springframework.stereotype.Service;
-
 import java.util.ArrayList;
 import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class SyncWithGithubService {
+
     private final GithubClient githubClient;
     private final GithubRepositoryRepository githubRepositoryRepository;
     private final UserRepository userRepository;
@@ -59,7 +57,9 @@ public class SyncWithGithubService {
 
             for (String file : solutionFiles) {
                 String sourceCode = githubClient.getContent(repo, file);
-                result.add(new String[] {file, sourceCode});
+                if (sourceCode != null) {
+                    result.add(new String[]{file, sourceCode});
+                }
             }
 
             return result;

--- a/backend/src/main/java/com/example/backend/lib/GithubClient.java
+++ b/backend/src/main/java/com/example/backend/lib/GithubClient.java
@@ -2,14 +2,9 @@ package com.example.backend.lib;
 
 import com.example.backend.util.JWTGenerator;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.io.IOException;
-import java.net.HttpURLConnection;
-import java.net.URL;
-import java.nio.charset.StandardCharsets;
-import java.util.Base64;
-import java.util.HashMap;
-import java.util.List;
+
 import lombok.extern.slf4j.Slf4j;
+
 import org.kohsuke.github.GHAppInstallation;
 import org.kohsuke.github.GHAppInstallationToken;
 import org.kohsuke.github.GHContent;
@@ -19,6 +14,14 @@ import org.kohsuke.github.GitHubBuilder;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.List;
 
 @Slf4j
 @Component

--- a/backend/src/main/java/com/example/backend/lib/GithubClient.java
+++ b/backend/src/main/java/com/example/backend/lib/GithubClient.java
@@ -2,8 +2,11 @@ package com.example.backend.lib;
 
 import com.example.backend.util.JWTGenerator;
 
+import lombok.extern.slf4j.Slf4j;
+
 import org.kohsuke.github.GHAppInstallation;
 import org.kohsuke.github.GHAppInstallationToken;
+import org.kohsuke.github.GHContent;
 import org.kohsuke.github.GHTreeEntry;
 import org.kohsuke.github.GitHub;
 import org.kohsuke.github.GitHubBuilder;
@@ -12,8 +15,12 @@ import org.springframework.stereotype.Component;
 
 import java.util.List;
 
+@Slf4j
 @Component
 public class GithubClient {
+
+    private final long ttlMillis = 600000;
+
     @Value("${github.app.id}")
     private String githubAppId;
 
@@ -23,7 +30,8 @@ public class GithubClient {
     @Value("${github.app.installationId}")
     private Long githubAppInstallationId;
 
-    private final long ttlMillis = 600000;
+    @Value("${github.app.maxFileSize}")
+    private Long githubAppMaxFileSize;
 
     public Boolean isPathExist(String repo) {
         try {
@@ -63,7 +71,12 @@ public class GithubClient {
     public String getContent(String repo, String path) {
         try {
             GitHub github = buildGithub();
-            return github.getRepository(repo).getFileContent(path).getContent();
+            GHContent content = github.getRepository(repo).getFileContent(path);
+            if (content.getSize() > githubAppMaxFileSize) {
+                log.error("{} file size is over max file size", path);
+                return null;
+            }
+            return content.getContent();
         } catch (Exception e) {
             e.printStackTrace();
             return null;

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -4,20 +4,26 @@ aws.paramstore.enabled=true
 aws.paramstore.prefix=/config
 aws.paramstore.name=algosolved
 aws.paramstore.profile-separator=_
+
 # database
 spring.datasource.url=${db.url}
 spring.datasource.username=${db.username}
 spring.datasource.password=${db.password}
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
+
 # server
 server.port=8080
+
 # security
 spring.security.oauth2.client.registration.github.clientId=${github.oauth.client.id}
 spring.security.oauth2.client.registration.github.clientSecret=${github.oauth.client.secret}
+
 # flyway-migration
 spring.flyway.out-of-order=true
+
 # api convention
 server.servlet.contextPath=/api
+
 # github
 github.app.id=${github.app.id}
 github.app.installationId=${github.app.installationId}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,31 +1,25 @@
 # aws ssm parameter store
 spring.config.import=aws-parameterstore:
-
 aws.paramstore.enabled=true
 aws.paramstore.prefix=/config
 aws.paramstore.name=algosolved
 aws.paramstore.profile-separator=_
-
 # database
 spring.datasource.url=${db.url}
 spring.datasource.username=${db.username}
 spring.datasource.password=${db.password}
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
-
 # server
 server.port=8080
-
 # security
 spring.security.oauth2.client.registration.github.clientId=${github.oauth.client.id}
 spring.security.oauth2.client.registration.github.clientSecret=${github.oauth.client.secret}
-
 # flyway-migration
 spring.flyway.out-of-order=true
-
 # api convention
 server.servlet.contextPath=/api
-
 # github
 github.app.id=${github.app.id}
 github.app.installationId=${github.app.installationId}
 github.app.privateKey=${github.app.privateKey}
+github.app.maxFileSize=65536

--- a/backend/src/test/java/com/example/backend/github/SyncWithGithubServiceTest.java
+++ b/backend/src/test/java/com/example/backend/github/SyncWithGithubServiceTest.java
@@ -23,13 +23,12 @@ import java.util.List;
 
 @ExtendWith(MockitoExtension.class)
 public class SyncWithGithubServiceTest {
+
+    User user;
     @Mock private GithubClient githubClient;
     @Mock private GithubRepositoryRepository githubRepositoryRepository;
     @Mock private UserRepository userRepository;
-
     @InjectMocks private SyncWithGithubService syncWithGithubService;
-
-    User user;
 
     @BeforeEach
     public void setUp() {
@@ -129,6 +128,27 @@ public class SyncWithGithubServiceTest {
         }
 
         @Test
+        @DisplayName("해당 레포지토리에 백준 솔루션 파일이 최대 길이 제한 보다 큰 경우 파일과 null을 반환한다.")
+        public void BackjoonSolutionSizeOverFileTest() {
+            user =
+                    User.builder()
+                            .username("uchan")
+                            .name("uchan")
+                            .profileImageUrl("image-url")
+                            .githubUrl("github-url")
+                            .build();
+            GithubRepository githubRepository =
+                    GithubRepository.builder().user(user).repo("repo").build();
+            when(githubClient.getAllFiles(githubRepository.getRepo()))
+                    .thenReturn(List.of("백준/Bronze/1000. A＋B/A＋B.py"));
+            when(githubClient.getContent(githubRepository.getRepo(), "백준/Bronze/1000. A＋B/A＋B.py"))
+                    .thenReturn(null);
+
+            List<String[]> result = syncWithGithubService.fetch(githubRepository);
+            Assertions.assertTrue(result.isEmpty());
+        }
+
+        @Test
         @DisplayName("해당 레포지토리에 프로그래머스 솔루션 파일이 있는 경우 파일과 코드를 반환한다.")
         public void ProgrammersSolutionFileTest() {
             User user =
@@ -149,6 +169,28 @@ public class SyncWithGithubServiceTest {
             List<String[]> result = syncWithGithubService.fetch(githubRepository);
             Assertions.assertEquals(result.get(0)[0], "프로그래머스/0/1. 두 정수 사이의 합/두 정수 사이의 합.py");
             Assertions.assertEquals(result.get(0)[1], "def solution(a, b): return a + b");
+        }
+
+        @Test
+        @DisplayName("해당 레포지토리에 프로그래머스 솔루션 파일이 최대 길이 제한 보다 큰 경우 파일과 null을 반환한다.")
+        public void ProgrammersSolutionSizeOverFileTest() {
+            User user =
+                    User.builder()
+                            .username("uchan")
+                            .name("uchan")
+                            .profileImageUrl("image-url")
+                            .githubUrl("github-url")
+                            .build();
+            GithubRepository githubRepository =
+                    GithubRepository.builder().user(user).repo("repo").build();
+            when(githubClient.getAllFiles(githubRepository.getRepo()))
+                    .thenReturn(List.of("프로그래머스/0/1. 두 정수 사이의 합/두 정수 사이의 합.py"));
+            when(githubClient.getContent(
+                            githubRepository.getRepo(), "프로그래머스/0/1. 두 정수 사이의 합/두 정수 사이의 합.py"))
+                    .thenReturn(null);
+
+            List<String[]> result = syncWithGithubService.fetch(githubRepository);
+            Assertions.assertTrue(result.isEmpty());
         }
     }
 }

--- a/backend/src/test/java/com/example/backend/github/SyncWithGithubServiceTest.java
+++ b/backend/src/test/java/com/example/backend/github/SyncWithGithubServiceTest.java
@@ -28,6 +28,7 @@ public class SyncWithGithubServiceTest {
     @Mock private GithubClient githubClient;
     @Mock private GithubRepositoryRepository githubRepositoryRepository;
     @Mock private UserRepository userRepository;
+
     @InjectMocks private SyncWithGithubService syncWithGithubService;
 
     @BeforeEach
@@ -130,27 +131,6 @@ public class SyncWithGithubServiceTest {
         }
 
         @Test
-        @DisplayName("해당 레포지토리에 백준 솔루션 파일이 최대 길이 제한 보다 큰 경우 파일과 null을 반환한다.")
-        public void BackjoonSolutionSizeOverFileTest() {
-            user =
-                    User.builder()
-                            .username("uchan")
-                            .name("uchan")
-                            .profileImageUrl("image-url")
-                            .githubUrl("github-url")
-                            .build();
-            GithubRepository githubRepository =
-                    GithubRepository.builder().user(user).repo("repo").build();
-            when(githubClient.getAllFiles(githubRepository.getRepo()))
-                    .thenReturn(List.of("백준/Bronze/1000. A＋B/A＋B.py"));
-            when(githubClient.getContent(githubRepository.getRepo(), "백준/Bronze/1000. A＋B/A＋B.py"))
-                    .thenReturn(null);
-
-            List<String[]> result = syncWithGithubService.fetch(githubRepository);
-            Assertions.assertTrue(result.isEmpty());
-        }
-
-        @Test
         @DisplayName("해당 레포지토리에 프로그래머스 솔루션 파일이 있는 경우 파일과 코드를 반환한다.")
         public void ProgrammersSolutionFileTest() {
             User user =
@@ -172,28 +152,6 @@ public class SyncWithGithubServiceTest {
             List<String[]> result = syncWithGithubService.fetch(githubRepository);
             Assertions.assertEquals(result.get(0)[0], "프로그래머스/0/1. 두 정수 사이의 합/두 정수 사이의 합.py");
             Assertions.assertEquals(result.get(0)[1], "def solution(a, b): return a + b");
-        }
-
-        @Test
-        @DisplayName("해당 레포지토리에 프로그래머스 솔루션 파일이 최대 길이 제한 보다 큰 경우 파일과 null을 반환한다.")
-        public void ProgrammersSolutionSizeOverFileTest() {
-            User user =
-                    User.builder()
-                            .username("uchan")
-                            .name("uchan")
-                            .profileImageUrl("image-url")
-                            .githubUrl("github-url")
-                            .build();
-            GithubRepository githubRepository =
-                    GithubRepository.builder().user(user).repo("repo").build();
-            when(githubClient.getAllFiles(githubRepository.getRepo()))
-                    .thenReturn(List.of("프로그래머스/0/1. 두 정수 사이의 합/두 정수 사이의 합.py"));
-            when(githubClient.getContent(
-                            githubRepository.getRepo(), "프로그래머스/0/1. 두 정수 사이의 합/두 정수 사이의 합.py"))
-                    .thenReturn(null);
-
-            List<String[]> result = syncWithGithubService.fetch(githubRepository);
-            Assertions.assertTrue(result.isEmpty());
         }
     }
 }

--- a/backend/src/test/java/com/example/backend/user/UserServiceTest.java
+++ b/backend/src/test/java/com/example/backend/user/UserServiceTest.java
@@ -23,12 +23,10 @@ import java.util.Optional;
 
 @ExtendWith(MockitoExtension.class)
 public class UserServiceTest {
+    User user;
     @Mock private GithubClient githubClient;
-
     @InjectMocks private UserService userService;
     @Mock private UserRepository userRepository;
-
-    User user;
 
     @BeforeEach
     public void setUp() {

--- a/backend/src/test/resources/application.properties
+++ b/backend/src/test/resources/application.properties
@@ -15,3 +15,4 @@ spring.flyway.out-of-order=true
 github.app.id=test-1
 github.app.installationId=123
 github.app.privateKey=test-private-key
+github.app.maxFileSize=65536


### PR DESCRIPTION
## 작업 내용
- 소스 코드 길이를 제한합니다.
- 우선 65536 byte 로 제한하였는데, 이 길이로 제한할지 논의가 필요할 것 같습니다.
- 백준에 경우 아래 링크를 참고 하였습니다. 프로그래머스의 경우 레퍼런스를 찾지 못했습니다.
- 테스트 실패 부분은 작업되어있는 PR 이 있어 따로 수정하지 않았습니다.

**참고 링크**
- [백준 게시판1](https://www.acmicpc.net/board/view/4052)
- [백준 게시판2](https://www.acmicpc.net/board/view/125647#:~:text=%ED%8A%B9%EB%B3%84%ED%95%9C%20%EB%AA%85%EC%8B%9C%EA%B0%80%20%EC%97%86%EB%8B%A4%EB%A9%B4%20%EC%A0%9C%EC%B6%9C%ED%95%A0,%EB%A7%8C%20B%EB%A5%BC%20%EB%84%98%EC%A7%80%20%EC%95%8A%EC%8A%B5%EB%8B%88%EB%8B%A4.)
- [백준 게시판3](https://www.acmicpc.net/board/view/22499)




## 이슈
- 너무 큰 코드의 길이의 경우 오래 걸리고 메모리 문제가 있을 수 있습니다.

## 체크 리스트
- Merge/배포 후에 체크해야할 사항이 있으면 적어주세요.
