### PR TITLE
Async 어노테이션 추가 및 테스트 코드 변경

### DIFF
--- a/backend/src/main/java/com/example/backend/BackendApplication.java
+++ b/backend/src/main/java/com/example/backend/BackendApplication.java
@@ -2,7 +2,9 @@ package com.example.backend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableAsync;
 
+@EnableAsync
 @SpringBootApplication
 public class BackendApplication {
 

--- a/backend/src/main/java/com/example/backend/github/controller/GithubRepositoryController.java
+++ b/backend/src/main/java/com/example/backend/github/controller/GithubRepositoryController.java
@@ -5,14 +5,8 @@ import com.example.backend.github.domain.GithubRepository;
 import com.example.backend.github.repository.GithubRepositoryRepository;
 import com.example.backend.github.response.GithubRepositoryStatus;
 import com.example.backend.github.service.SyncWithGithubService;
-import com.example.backend.problem.domain.Problem;
-import com.example.backend.problem.service.ProblemService;
-import com.example.backend.solution.common.enums.LanguageType;
-import com.example.backend.solution.domain.Solution;
-import com.example.backend.solution.service.SolutionService;
-
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
-
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -20,18 +14,13 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 
-import java.util.List;
-import java.util.Map;
-
 @Controller
 @RequiredArgsConstructor
 @RequestMapping("/v1/github-repositories")
 public class GithubRepositoryController {
 
     private final SyncWithGithubService syncWithGithubService;
-    private final ProblemService problemService;
     private final GithubRepositoryRepository githubRepositoryRepository;
-    private final SolutionService solutionService;
 
     @PostMapping("/connect")
     public ResponseEntity<Boolean> connect(@RequestBody Map<String, Object> payload) {
@@ -51,33 +40,17 @@ public class GithubRepositoryController {
     public ResponseEntity<Integer> sync(@RequestBody Map<String, Object> payload) {
         // TODO: 현재 유저와 동일한지 확인필요
 
-        int count = 0;
-
         Long githubRepositoryId = Long.parseLong(String.valueOf(payload.get("githubRepositoryId")));
         GithubRepository githubRepository =
                 githubRepositoryRepository.findById(githubRepositoryId).get();
 
-        List<String[]> solutionFiles = syncWithGithubService.fetch(githubRepository);
-
-        for (String[] fileAndCode : solutionFiles) {
-            String file = fileAndCode[0];
-            String sourceCode = fileAndCode[1];
-            Problem problem = problemService.getOrCreateFromFile(file);
-
-            LanguageType languageType = LanguageType.getLanguageType(file);
-            Solution solution =
-                    solutionService.createSolution(
-                            githubRepository, problem, languageType, sourceCode);
-            if (solution != null) {
-                count++;
-            }
-        }
+        syncWithGithubService.fetch(githubRepository);
 
         return new ResponseEntity(
                 BaseResponse.success(
                         GithubRepositoryStatus.SUCCESS.getCode(),
                         GithubRepositoryStatus.SUCCESS.getMessage(),
-                        count),
+                        ""),
                 HttpStatus.OK);
     }
 }

--- a/backend/src/main/java/com/example/backend/github/controller/GithubRepositoryController.java
+++ b/backend/src/main/java/com/example/backend/github/controller/GithubRepositoryController.java
@@ -5,14 +5,17 @@ import com.example.backend.github.domain.GithubRepository;
 import com.example.backend.github.repository.GithubRepositoryRepository;
 import com.example.backend.github.response.GithubRepositoryStatus;
 import com.example.backend.github.service.SyncWithGithubService;
-import java.util.Map;
+
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+
+import java.util.Map;
 
 @Controller
 @RequiredArgsConstructor

--- a/backend/src/main/java/com/example/backend/github/service/SyncWithGithubService.java
+++ b/backend/src/main/java/com/example/backend/github/service/SyncWithGithubService.java
@@ -10,11 +10,14 @@ import com.example.backend.solution.domain.Solution;
 import com.example.backend.solution.service.SolutionService;
 import com.example.backend.user.domain.User;
 import com.example.backend.user.repository.UserRepository;
-import java.util.ArrayList;
-import java.util.List;
+
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor

--- a/backend/src/main/java/com/example/backend/github/service/SyncWithGithubService.java
+++ b/backend/src/main/java/com/example/backend/github/service/SyncWithGithubService.java
@@ -52,7 +52,7 @@ public class SyncWithGithubService {
     }
 
     @Async
-    public boolean fetch(GithubRepository githubRepository) {
+    public void fetch(GithubRepository githubRepository) {
         try {
             List<String[]> result = new ArrayList<>();
             String repo = githubRepository.getRepo();
@@ -73,10 +73,8 @@ public class SyncWithGithubService {
                                 githubRepository, problem, languageType, sourceCode);
             }
 
-            return true;
         } catch (Exception e) {
             System.out.println(e);
-            return false;
         }
     }
 }

--- a/backend/src/main/java/com/example/backend/solution/service/SolutionService.java
+++ b/backend/src/main/java/com/example/backend/solution/service/SolutionService.java
@@ -12,13 +12,11 @@ import com.example.backend.solution.domain.Solution;
 import com.example.backend.solution.dto.SolutionDTO;
 import com.example.backend.solution.dto.SolutionDetailDTO;
 import com.example.backend.solution.repository.SolutionRepository;
-
-import lombok.RequiredArgsConstructor;
-
-import org.springframework.stereotype.Service;
-
 import java.util.List;
 import java.util.stream.Collectors;
+import javax.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
@@ -47,6 +45,7 @@ public class SolutionService {
         return SolutionDetailDTO.mapToDTO(solution);
     }
 
+    @Transactional
     public Solution createSolution(
             GithubRepository githubRepository,
             Problem problem,

--- a/backend/src/main/java/com/example/backend/solution/service/SolutionService.java
+++ b/backend/src/main/java/com/example/backend/solution/service/SolutionService.java
@@ -12,11 +12,15 @@ import com.example.backend.solution.domain.Solution;
 import com.example.backend.solution.dto.SolutionDTO;
 import com.example.backend.solution.dto.SolutionDetailDTO;
 import com.example.backend.solution.repository.SolutionRepository;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.stereotype.Service;
+
 import java.util.List;
 import java.util.stream.Collectors;
+
 import javax.transaction.Transactional;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor

--- a/backend/src/test/java/com/example/backend/github/GithubRepositoryControllerTest.java
+++ b/backend/src/test/java/com/example/backend/github/GithubRepositoryControllerTest.java
@@ -15,7 +15,8 @@ import com.example.backend.problem.service.ProblemService;
 import com.example.backend.solution.common.enums.LanguageType;
 import com.example.backend.solution.domain.Solution;
 import com.example.backend.solution.service.SolutionService;
-
+import java.util.ArrayList;
+import java.util.List;
 import org.instancio.Instancio;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -26,9 +27,6 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
-
-import java.util.ArrayList;
-import java.util.List;
 
 @WebMvcTest(GithubRepositoryController.class)
 public class GithubRepositoryControllerTest {
@@ -111,7 +109,6 @@ public class GithubRepositoryControllerTest {
             Solution solution = Instancio.create(Solution.class);
             given(githubRepositoryRepository.findById(1L))
                     .willReturn(java.util.Optional.of(githubRepository));
-            given(syncWithGithubService.fetch(githubRepository)).willReturn(solutionFiles);
             given(problemService.getOrCreateFromFile(file)).willReturn(problem);
             given(
                             solutionService.createSolution(
@@ -137,7 +134,7 @@ public class GithubRepositoryControllerTest {
                     {
                         "code": "2000",
                         "message": "요청에 성공하였습니다.",
-                        "data": 1
+                        "data": ""
                     }
                     """));
         }

--- a/backend/src/test/java/com/example/backend/github/GithubRepositoryControllerTest.java
+++ b/backend/src/test/java/com/example/backend/github/GithubRepositoryControllerTest.java
@@ -15,8 +15,7 @@ import com.example.backend.problem.service.ProblemService;
 import com.example.backend.solution.common.enums.LanguageType;
 import com.example.backend.solution.domain.Solution;
 import com.example.backend.solution.service.SolutionService;
-import java.util.ArrayList;
-import java.util.List;
+
 import org.instancio.Instancio;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -27,6 +26,9 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @WebMvcTest(GithubRepositoryController.class)
 public class GithubRepositoryControllerTest {

--- a/backend/src/test/java/com/example/backend/github/SyncWithGithubServiceTest.java
+++ b/backend/src/test/java/com/example/backend/github/SyncWithGithubServiceTest.java
@@ -131,9 +131,8 @@ public class SyncWithGithubServiceTest {
                     .thenReturn(problem);
 
 
-            boolean success = syncWithGithubService.fetch(githubRepository);
+            syncWithGithubService.fetch(githubRepository);
 
-            Assertions.assertTrue(success);
             verify(githubClient).getAllFiles(githubRepository.getRepo());
             verify(githubClient).getContent(githubRepository.getRepo(), "백준/Bronze/1000. A＋B/A＋B.py");
             verify(solutionService).createSolution(githubRepository, problem, LanguageType.python, "a, b = map(int, input().split()); print(a+b)");
@@ -163,9 +162,8 @@ public class SyncWithGithubServiceTest {
                     .thenReturn(problem);
 
 
-            boolean success = syncWithGithubService.fetch(githubRepository);
+            syncWithGithubService.fetch(githubRepository);
 
-            Assertions.assertTrue(success);
             verify(githubClient).getAllFiles(githubRepository.getRepo());
             verify(githubClient).getContent(githubRepository.getRepo(), "프로그래머스/0/1. 두 정수 사이의 합/두 정수 사이의 합.py");
             verify(solutionService).createSolution(githubRepository, problem, LanguageType.python, "def solution(a, b): return a + b");

--- a/backend/src/test/java/com/example/backend/github/SyncWithGithubServiceTest.java
+++ b/backend/src/test/java/com/example/backend/github/SyncWithGithubServiceTest.java
@@ -16,7 +16,7 @@ import com.example.backend.solution.repository.SolutionRepository;
 import com.example.backend.solution.service.SolutionService;
 import com.example.backend.user.domain.User;
 import com.example.backend.user.repository.UserRepository;
-import java.util.List;
+
 import org.instancio.Instancio;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -27,6 +27,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
 
 @ExtendWith(MockitoExtension.class)
 public class SyncWithGithubServiceTest {
@@ -130,12 +132,17 @@ public class SyncWithGithubServiceTest {
             when(problemService.getOrCreateFromFile("백준/Bronze/1000. A＋B/A＋B.py"))
                     .thenReturn(problem);
 
-
             syncWithGithubService.fetch(githubRepository);
 
             verify(githubClient).getAllFiles(githubRepository.getRepo());
-            verify(githubClient).getContent(githubRepository.getRepo(), "백준/Bronze/1000. A＋B/A＋B.py");
-            verify(solutionService).createSolution(githubRepository, problem, LanguageType.python, "a, b = map(int, input().split()); print(a+b)");
+            verify(githubClient)
+                    .getContent(githubRepository.getRepo(), "백준/Bronze/1000. A＋B/A＋B.py");
+            verify(solutionService)
+                    .createSolution(
+                            githubRepository,
+                            problem,
+                            LanguageType.python,
+                            "a, b = map(int, input().split()); print(a+b)");
         }
 
         @Test
@@ -161,12 +168,17 @@ public class SyncWithGithubServiceTest {
             when(problemService.getOrCreateFromFile("프로그래머스/0/1. 두 정수 사이의 합/두 정수 사이의 합.py"))
                     .thenReturn(problem);
 
-
             syncWithGithubService.fetch(githubRepository);
 
             verify(githubClient).getAllFiles(githubRepository.getRepo());
-            verify(githubClient).getContent(githubRepository.getRepo(), "프로그래머스/0/1. 두 정수 사이의 합/두 정수 사이의 합.py");
-            verify(solutionService).createSolution(githubRepository, problem, LanguageType.python, "def solution(a, b): return a + b");
+            verify(githubClient)
+                    .getContent(githubRepository.getRepo(), "프로그래머스/0/1. 두 정수 사이의 합/두 정수 사이의 합.py");
+            verify(solutionService)
+                    .createSolution(
+                            githubRepository,
+                            problem,
+                            LanguageType.python,
+                            "def solution(a, b): return a + b");
         }
     }
 }


### PR DESCRIPTION
## 작업 내용
- Async 어노테이션을 이용하여 깃허브에서 문제를 가져오는 fetch메소드를 비동기 처리합니다.
- fetch로 가져오고, 리턴 값에 대해서 controller 단에서 처리하지 못하기 때문에 코드를 이동하고, 테스트 코드는 Mock으로 된 코드의 경우 실제 DB에 저장하기 위해서 처리가 많이 필요하여, 특정 메소드가 호출되었는 지 확인하도록 하였습니다. 
- 솔루션 생성 시 트랜잭션 보장을 위해 transactional 어노테이션을 추가합니다.
- 기존 응답 값을 count 대신 빈 문자열을 리턴하도록 변경합니다.
<img width="891" alt="Screenshot 2024-04-14 at 1 25 28 PM" src="https://github.com/AlgoSolved/AlgoSolved/assets/47859845/ff0da446-6062-40a0-aa2a-8292180b7ba6">


## 체크 리스트
- [ ] API 가 비동기로 호출되는지 확인
