### PR TITLE
alb 추가 및 Ec2 연결

### DIFF
--- a/.github/workflows/TERRAFORM-PLAN.yml
+++ b/.github/workflows/TERRAFORM-PLAN.yml
@@ -84,6 +84,7 @@ jobs:
           terraform_version: ${{ env.TF_VERSION }}
 
       - name: Create tfvars file from Encrypted Secrets
+      if: ${{ steps.check-file.outputs.exist == 'true' }}
         env:
           LARGE_SECRET_PASSPHRASE: ${{ secrets.LARGE_SECRET_PASSPHRASE }}
         run: |

--- a/.github/workflows/TERRAFORM-PLAN.yml
+++ b/.github/workflows/TERRAFORM-PLAN.yml
@@ -84,7 +84,7 @@ jobs:
           terraform_version: ${{ env.TF_VERSION }}
 
       - name: Create tfvars file from Encrypted Secrets
-      if: ${{ steps.check-file.outputs.exist == 'true' }}
+        if: ${{ steps.check-file.outputs.exist == 'true' }}
         env:
           LARGE_SECRET_PASSPHRASE: ${{ secrets.LARGE_SECRET_PASSPHRASE }}
         run: |

--- a/infra/README.md
+++ b/infra/README.md
@@ -24,7 +24,7 @@ infra
 
 ```
 # encrypt
-gpg --output terraform.tfvars --decrypt terraform.tfvars.gpg
+gpg --symmetric --cipher-algo AES256 terraform.tfvars
 
 ```
 

--- a/infra/README.md
+++ b/infra/README.md
@@ -7,8 +7,8 @@
 
 <img width="1026" alt="image" src="https://github.com/AlgoSolved/AlgoSolved/assets/57058726/697c114e-b820-409a-a50e-033438ac1d18">
 
-
 ### 폴더 구조
+
 ```
 
 infra
@@ -20,3 +20,16 @@ infra
 
 ```
 
+### terraform tfvars
+
+```
+# encrypt
+gpg --output terraform.tfvars --decrypt terraform.tfvars.gpg
+
+```
+
+```
+# decrypt
+gpg --output terraform.tfvars --decrypt terraform.tfvars.gpg
+
+```

--- a/infra/aws/prod/asg.tf
+++ b/infra/aws/prod/asg.tf
@@ -75,6 +75,7 @@ resource "aws_autoscaling_group" "algosolved-ec2-asg" {
   min_size            = 0
   desired_capacity    = 0
   vpc_zone_identifier = [var.sub_pub_a_id, var.sub_pub_b_id, var.sub_pub_c_id, var.sub_pub_d_id]
+  target_group_arns   = [aws_lb_target_group.algosolved-lb-tg.arn]
 
   launch_template {
     id      = aws_launch_template.algosolved-lt.id
@@ -91,18 +92,6 @@ resource "aws_autoscaling_group" "algosolved-ec2-asg" {
     key                 = "Stage"
     value               = var.stage
     propagate_at_launch = true
-  }
-}
-
-resource "aws_instance" "algoSolved-ec2" {
-  ami = data.aws_ami.ubuntu.id
-
-  launch_template {
-    id = aws_launch_template.algosolved-lt.id
-  }
-  tags = {
-    Project = var.project
-    Stage   = var.stage
   }
 }
 

--- a/infra/aws/prod/asg.tf
+++ b/infra/aws/prod/asg.tf
@@ -93,3 +93,16 @@ resource "aws_autoscaling_group" "algosolved-ec2-asg" {
     propagate_at_launch = true
   }
 }
+
+resource "aws_instance" "algoSolved-ec2" {
+  ami = data.aws_ami.ubuntu.id
+
+  launch_template {
+    id = aws_launch_template.algosolved-lt.id
+  }
+  tags = {
+    Project = var.project
+    Stage   = var.stage
+  }
+}
+

--- a/infra/aws/prod/elb.tf
+++ b/infra/aws/prod/elb.tf
@@ -1,113 +1,113 @@
 resource "aws_lb" "algosolved-lb" {
-    name                       = "algosolved-alb"
-    load_balancer_type         = "application"
-    idle_timeout               = 120
-    ip_address_type            = "ipv4"
+  name               = "algosolved-alb"
+  load_balancer_type = "application"
+  idle_timeout       = 120
+  ip_address_type    = "ipv4"
 
-    security_groups = [
-        aws_security_group.algosolved-ec2-sg.id
-    ]
+  security_groups = [
+    aws_security_group.algosolved-ec2-sg.id
+  ]
 
-    subnets = [
-        var.sub_pub_a_id,
-        var.sub_pub_c_id
-    ]
+  subnets = [
+    var.sub_pub_a_id,
+    var.sub_pub_c_id
+  ]
 
-    timeouts {}
+  timeouts {}
 
-    tags = {
-        Project = var.project
-        Stage   = var.stage
-    }
-    tags_all = {
-        Project = var.project
-        Stage   = var.stage
-    }
+  tags = {
+    Project = var.project
+    Stage   = var.stage
+  }
+  tags_all = {
+    Project = var.project
+    Stage   = var.stage
+  }
 }
 
 
 // target-group
 resource "aws_lb_target_group" "algosolved-lb-tg" {
-    name                 = "algosolved-ec2-target-group"
-    deregistration_delay = 15
-    protocol             = "HTTP"
-    port                 = 80
-    vpc_id               = var.vpc_id
+  name                 = "algosolved-ec2-target-group"
+  deregistration_delay = 15
+  protocol             = "HTTP"
+  port                 = 80
+  vpc_id               = var.vpc_id
 
-    health_check {
-        healthy_threshold   = 2
-        interval            = 30
-        port                = "traffic-port"
-        path                = "/api/health/ping"
-        unhealthy_threshold = 10
-        matcher             = 200
-        timeout             = 10
-    }
+  health_check {
+    healthy_threshold   = 2
+    interval            = 30
+    port                = "traffic-port"
+    path                = "/api/health/ping"
+    unhealthy_threshold = 10
+    matcher             = 200
+    timeout             = 10
+  }
 
-    tags = {
-        Project = var.project
-        Stage   = var.stage
-    }
-    tags_all = {
-        Project = var.project
-        Stage   = var.stage
-    }
+  tags = {
+    Project = var.project
+    Stage   = var.stage
+  }
+  tags_all = {
+    Project = var.project
+    Stage   = var.stage
+  }
 }
 
 // 리스너
 resource "aws_alb_listener" "algosolved-http-forward" {
-    load_balancer_arn = aws_lb.algosolved-lb.arn
-    port              = "80"
-    protocol          = "HTTP"
+  load_balancer_arn = aws_lb.algosolved-lb.arn
+  port              = "80"
+  protocol          = "HTTP"
 
-    default_action {
-        type = "redirect"
+  default_action {
+    type = "redirect"
 
-        redirect {
-            port        = "443"
-            protocol    = "HTTPS"
-            status_code = "HTTP_301"
-        }
+    redirect {
+      port        = "443"
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
     }
+  }
 
 
-    tags = {
-        Project = var.project
-        Stage   = var.stage
-    }
-    tags_all = {
-        Project = var.project
-        Stage   = var.stage
-    }
+  tags = {
+    Project = var.project
+    Stage   = var.stage
+  }
+  tags_all = {
+    Project = var.project
+    Stage   = var.stage
+  }
 }
 
 resource "aws_alb_listener" "algosolved-https-listener" {
-    load_balancer_arn = aws_lb.algosolved-lb.arn
-    port              = 443
-    protocol          = "HTTPS"
-    ssl_policy        = "ELBSecurityPolicy-TLS-1-2-2017-01"
+  load_balancer_arn = aws_lb.algosolved-lb.arn
+  port              = 443
+  protocol          = "HTTPS"
+  ssl_policy        = "ELBSecurityPolicy-TLS-1-2-2017-01"
 
-    default_action {
-        order = 1
-        type  = "fixed-response"
+  default_action {
+    order = 1
+    type  = "fixed-response"
 
-        fixed_response {
-            content_type = "text/plain"
-            message_body = "not found resource"
-            status_code  = "404"
-        }
+    fixed_response {
+      content_type = "text/plain"
+      message_body = "not found resource"
+      status_code  = "404"
     }
+  }
 
-    timeouts {}
+  timeouts {}
 
-    tags = {
-        Project = var.project
-        Stage   = var.stage
-    }
-    tags_all = {
-        Project = var.project
-        Stage   = var.stage
-    }
+  tags = {
+    Project = var.project
+    Stage   = var.stage
+  }
+  tags_all = {
+    Project = var.project
+    Stage   = var.stage
+  }
 }
 
 // 아래 호스트 해더는 추후 도메인 연결 시 바꿀 것

--- a/infra/aws/prod/elb.tf
+++ b/infra/aws/prod/elb.tf
@@ -116,3 +116,24 @@ resource "aws_alb_listener" "algosolved-https-listener" {
 }
 
 
+resource "aws_lb_listener_rule" "algosolved-alb-rule" {
+  listener_arn = aws_alb_listener.algosolved-https-listener.arn
+  priority     = 1
+
+  condition {
+    host_header {
+      values = ["algosolved.com"]
+    }
+  }
+
+  action {
+    type = "forward"
+    forward {
+      target_group {
+        arn    = aws_lb_target_group.algosolved-lb-tg.arn
+        weight = 100
+      }
+    }
+  }
+}
+

--- a/infra/aws/prod/elb.tf
+++ b/infra/aws/prod/elb.tf
@@ -1,0 +1,125 @@
+resource "aws_lb" "algosolved-lb" {
+    name                       = "algosolved-alb"
+    internal                   = false
+    load_balancer_type         = "application"
+    idle_timeout               = 120
+    enable_deletion_protection = true
+    enable_http2               = true
+    ip_address_type            = "ipv4"
+
+
+    drop_invalid_header_fields = false
+    security_groups = [
+        aws_security_group.algosolved-ec2-sg.id
+    ]
+
+    subnets = [
+        var.sub_pub_a_id,
+        var.sub_pub_c_id
+    ]
+
+    timeouts {}
+
+    tags = {
+        Project = var.project
+        Stage   = var.stage
+    }
+    tags_all = {
+        Project = var.project
+        Stage   = var.stage
+    }
+}
+
+
+// target-group
+resource "aws_lb_target_group" "algosolved-lb-tg" {
+    name                 = "algosolved-ec2-target-group"
+    deregistration_delay = 15
+    protocol             = "HTTP"
+    port                 = 80
+    vpc_id               = var.vpc_id
+
+    health_check {
+        enabled             = true
+        healthy_threshold   = 2
+        interval            = 30
+        port                = "traffic-port"
+        path                = "/api/health/ping"
+        protocol            = "HTTP"
+        unhealthy_threshold = 10
+        matcher             = 200
+        timeout             = 10
+    }
+
+    tags = {
+        Project = var.project
+        Stage   = var.stage
+    }
+    tags_all = {
+        Project = var.project
+        Stage   = var.stage
+    }
+}
+
+resource "aws_autoscaling_attachment" "terramino" {
+  autoscaling_group_name = aws_autoscaling_group.algosolved-ec2-asg.id
+  lb_target_group_arn   = aws_lb_target_group.algosolved-tg.arn
+}
+
+// 리스너
+resource "aws_alb_listener" "algosolved-http-forward" {
+    load_balancer_arn = aws_lb.algosolved-lb.arn
+    port              = "80"
+    protocol          = "HTTP"
+
+    default_action {
+        type = "redirect"
+
+        redirect {
+        port        = "443"
+        protocol    = "HTTPS"
+        status_code = "HTTP_301"
+        }
+    }
+
+
+    tags = {
+        Project = var.project
+        Stage   = var.stage
+    }
+    tags_all = {
+        Project = var.project
+        Stage   = var.stage
+    }
+}
+
+resource "aws_alb_listener" "algosolved-https-listener" {
+    load_balancer_arn = aws_lb.algosolved-lb.arn
+    port              = 443
+    protocol          = "HTTPS"
+    ssl_policy        = "ELBSecurityPolicy-TLS-1-2-2017-01"
+
+    default_action {
+        order = 1
+        type  = "fixed-response"
+
+        fixed_response {
+            content_type = "text/plain"
+            message_body = "not found resource"
+            status_code  = "404"
+        }
+    }
+
+    timeouts {}
+
+    tags = {
+        Project = var.project
+        Stage   = var.stage
+    }
+    tags_all = {
+        Project = var.project
+        Stage   = var.stage
+    }
+}
+
+

--- a/infra/aws/prod/elb.tf
+++ b/infra/aws/prod/elb.tf
@@ -54,9 +54,17 @@ resource "aws_lb_target_group" "algosolved-lb-tg" {
     }
 }
 
+// autoscaling - targetGroup
 resource "aws_autoscaling_attachment" "algosolved-asg-attachment" {
   autoscaling_group_name = aws_autoscaling_group.algosolved-ec2-asg.id
   lb_target_group_arn   = aws_lb_target_group.algosolved-lb-tg.arn
+}
+
+// targetGroup - ec2
+resource "aws_lb_target_group_attachment" "algosolved-tg-attachment" {
+  target_group_arn = aws_lb_target_group.algosolved-lb-tg.arn
+  target_id        = aws_instance.algoSolved-ec2.id
+  port             = 80
 }
 
 // 리스너

--- a/infra/aws/prod/elb.tf
+++ b/infra/aws/prod/elb.tf
@@ -10,7 +10,9 @@ resource "aws_lb" "algosolved-lb" {
 
   subnets = [
     var.sub_pub_a_id,
-    var.sub_pub_c_id
+    var.sub_pub_b_id,
+    var.sub_pub_c_id,
+    var.sub_pub_d_id,
   ]
 
   timeouts {}
@@ -88,14 +90,8 @@ resource "aws_alb_listener" "algosolved-https-listener" {
   ssl_policy        = "ELBSecurityPolicy-TLS-1-2-2017-01"
 
   default_action {
-    order = 1
-    type  = "fixed-response"
-
-    fixed_response {
-      content_type = "text/plain"
-      message_body = "not found resource"
-      status_code  = "404"
-    }
+    target_group_arn = aws_lb_target_group.algosolved-lb-tg.arn
+    type = "forward"
   }
 
   timeouts {}
@@ -107,28 +103,6 @@ resource "aws_alb_listener" "algosolved-https-listener" {
   tags_all = {
     Project = var.project
     Stage   = var.stage
-  }
-}
-
-// 아래 호스트 해더는 추후 도메인 연결 시 바꿀 것
-resource "aws_lb_listener_rule" "algosolved-alb-rule" {
-  listener_arn = aws_alb_listener.algosolved-https-listener.arn
-  priority     = 1
-
-  condition {
-    host_header {
-      values = ["algosolved.com"]
-    }
-  }
-
-  action {
-    type = "forward"
-    forward {
-      target_group {
-        arn    = aws_lb_target_group.algosolved-lb-tg.arn
-        weight = 100
-      }
-    }
   }
 }
 

--- a/infra/aws/prod/elb.tf
+++ b/infra/aws/prod/elb.tf
@@ -54,9 +54,9 @@ resource "aws_lb_target_group" "algosolved-lb-tg" {
     }
 }
 
-resource "aws_autoscaling_attachment" "terramino" {
+resource "aws_autoscaling_attachment" "algosolved-asg-attachment" {
   autoscaling_group_name = aws_autoscaling_group.algosolved-ec2-asg.id
-  lb_target_group_arn   = aws_lb_target_group.algosolved-tg.arn
+  lb_target_group_arn   = aws_lb_target_group.algosolved-lb-tg.arn
 }
 
 // 리스너

--- a/infra/aws/prod/elb.tf
+++ b/infra/aws/prod/elb.tf
@@ -91,7 +91,7 @@ resource "aws_alb_listener" "algosolved-https-listener" {
 
   default_action {
     target_group_arn = aws_lb_target_group.algosolved-lb-tg.arn
-    type = "forward"
+    type             = "forward"
   }
 
   timeouts {}

--- a/infra/aws/prod/elb.tf
+++ b/infra/aws/prod/elb.tf
@@ -54,19 +54,6 @@ resource "aws_lb_target_group" "algosolved-lb-tg" {
     }
 }
 
-// autoscaling - targetGroup
-resource "aws_autoscaling_attachment" "algosolved-asg-attachment" {
-  autoscaling_group_name = aws_autoscaling_group.algosolved-ec2-asg.id
-  lb_target_group_arn   = aws_lb_target_group.algosolved-lb-tg.arn
-}
-
-// targetGroup - ec2
-resource "aws_lb_target_group_attachment" "algosolved-tg-attachment" {
-  target_group_arn = aws_lb_target_group.algosolved-lb-tg.arn
-  target_id        = aws_instance.algoSolved-ec2.id
-  port             = 80
-}
-
 // 리스너
 resource "aws_alb_listener" "algosolved-http-forward" {
     load_balancer_arn = aws_lb.algosolved-lb.arn
@@ -123,7 +110,7 @@ resource "aws_alb_listener" "algosolved-https-listener" {
     }
 }
 
-
+// 아래 호스트 해더는 추후 도메인 연결 시 바꿀 것
 resource "aws_lb_listener_rule" "algosolved-alb-rule" {
   listener_arn = aws_alb_listener.algosolved-https-listener.arn
   priority     = 1

--- a/infra/aws/prod/elb.tf
+++ b/infra/aws/prod/elb.tf
@@ -1,14 +1,9 @@
 resource "aws_lb" "algosolved-lb" {
     name                       = "algosolved-alb"
-    internal                   = false
     load_balancer_type         = "application"
     idle_timeout               = 120
-    enable_deletion_protection = true
-    enable_http2               = true
     ip_address_type            = "ipv4"
 
-
-    drop_invalid_header_fields = false
     security_groups = [
         aws_security_group.algosolved-ec2-sg.id
     ]
@@ -40,12 +35,10 @@ resource "aws_lb_target_group" "algosolved-lb-tg" {
     vpc_id               = var.vpc_id
 
     health_check {
-        enabled             = true
         healthy_threshold   = 2
         interval            = 30
         port                = "traffic-port"
         path                = "/api/health/ping"
-        protocol            = "HTTP"
         unhealthy_threshold = 10
         matcher             = 200
         timeout             = 10
@@ -76,9 +69,9 @@ resource "aws_alb_listener" "algosolved-http-forward" {
         type = "redirect"
 
         redirect {
-        port        = "443"
-        protocol    = "HTTPS"
-        status_code = "HTTP_301"
+            port        = "443"
+            protocol    = "HTTPS"
+            status_code = "HTTP_301"
         }
     }
 


### PR DESCRIPTION
## 작업 내용
- ALB와 타겟그룹을 추가하고, 관련하여 헬스체크를 설정합니다.
- 관련된 autoScaling Atachment와 리스너를 추가합니다. HTTP 로 들어온 요청에 대해서 HTTPS 로 리다이렉트하도록 하였습니다.
- 헬스체크의 경우, 타겟이 설정 된 이후 최소 (healthy_threshold)2* interval(30초) = 60초 가 걸립니다.

| 리소스    | 옵션 이름 | 설명 |
| -------- | ------- |  ------- |
| aws_lb | load_balancer_type    |  로드벨런서의 타입으로 'application', 'network' 중 선택 가능(ALB, NLB) |
|    | idle_timeout   |  연결 유휴 시간(서버와 커넥션 유지 시간) Default 60초 ([참고링크](https://reaperes.medium.com/aws-alb-%EC%9D%98-idle-timeout-%EC%97%90-%EA%B4%80%ED%95%98%EC%97%AC-7addb8bfb886))  |
|    | ip_address_type   |  IP 주소 타입 (ipv4, dualstack) |
| aws_lb_target_group  | deregistration_delay    |  등록 취소 대기 시간, 타겟 그룹에서 드레이닝 -> 사용중지 로 변경될때까지 로드밸런싱을 대기하는 시간 기본값은 300 초 |
|    | health_check   | 헬스체크를 통해서 어플리케이션과 정상적으로 연결되어있는지 확인하는 설정이다. 헬스체크가 실패하면 새로 등록하려 한다.  |
|    | healthy_threshold   | 정상 여부를 체크하기 위한 연속 성공 횟수. 기본값은 3회 |
|    | interval   | 각 헬스체크를 시도하는 간격. 기본값은 30초  |
|    | port   | 대상 상태 확인을 위해 사용되는 포트로, 연결된 대상그룹과 동일한 경우 traffic-port, 또는 숫자로 표기  |
|    | path   | 헬스체크 관련 경로 |
|    | protocol   |  로드밸런서가 사용하는 프로토콜로 HTTP, TCP 중 하나이다.  |
|    | unhealthy_threshold   | 비정상 여부를 확인하는 연속 실패 횟수. 기본값은 3회  |
|    | matcher   |  성공적인 응답을 내려줄 때 확인 하는 코드. HTTP 또는 gRPC 코드  |
|    | timeout   |  대상으로 부터 해당 값에 시간동안 응답이 없는 경우 타임아웃으로 처리  |


