### PR TITLE
s3 FE artifact 파일 업로드 워크플로 및 정적호스팅 버킷 추가

### DIFF
--- a/.github/workflows/DEPLOY-FE.yml
+++ b/.github/workflows/DEPLOY-FE.yml
@@ -1,0 +1,25 @@
+name: DEPLOY FE
+
+on:
+  workflow_dispatch:
+
+env:
+  AWS_REGION: ap-northeast-2
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Configure AWS credentials for production
+        uses: aws-actions/configure-aws-credentials@v3
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Upload FE artifacts To S3
+        run: |
+          aws s3 cp ./frontend/public s3://algosolved-fe-bucket --recursive

--- a/.github/workflows/FE-DEPLOY.yml
+++ b/.github/workflows/FE-DEPLOY.yml
@@ -1,4 +1,4 @@
-name: DEPLOY FE
+name: FE DEPLOY
 
 on:
   workflow_dispatch:

--- a/infra/aws/prod/s3.tf
+++ b/infra/aws/prod/s3.tf
@@ -1,0 +1,48 @@
+resource "aws_s3_bucket" "algosolved-fe-bucket" {
+  bucket = "algosolved-fe-bucket"
+
+  tags = {
+    Name = "algosolved-fe-bucket"
+    Project = var.project
+    Stage   = var.stage
+  }
+}
+
+resource "aws_s3_bucket_policy" "public_bucket_policy" {
+  bucket = aws_s3_bucket.algosolved-fe-bucket.bucket
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect    = "Allow",
+        Principal = "*",
+        Action    = "s3:GetObject",
+        Resource  = "arn:aws:s3:::${aws_s3_bucket.algosolved-fe-bucket.bucket}/*",
+      },
+    ],
+  })
+}
+
+resource "aws_s3_bucket_public_access_block" "public_access_block" {
+  bucket = aws_s3_bucket.algosolved-fe-bucket.bucket
+
+  block_public_acls   = false
+  block_public_policy = false
+  ignore_public_acls  = false
+  restrict_public_buckets = false
+}
+
+resource "aws_s3_bucket_website_configuration" "algosolved-fe-bucket-website" {
+  depends_on = [
+    aws_s3_bucket.algosolved-fe-bucket,
+  ]
+  bucket = aws_s3_bucket.algosolved-fe-bucket.bucket
+
+  index_document {
+    suffix = "index.html"
+  }
+
+  error_document {
+    key = "error.html"
+  }
+}


### PR DESCRIPTION
## 작업 내용
- algosolved-fe-bucket 버킷 추가했습니다
  - 해당 버킷을 정적호스팅하기 위해 퍼블릭 액세스 및 정책 리소스도 같이 추가했습니다
- 해당 버킷에 FE 파일을 업로드하는 워크플로 추가했습니다

## 이슈
- FE 배포
