### PR TITLE
GitHub actions 최신화 및 상용 환경 소셜로그인 과정 및 페이지 수정

### DIFF
--- a/.github/workflows/BUILD-PRODUCTION-IMAGE.yml
+++ b/.github/workflows/BUILD-PRODUCTION-IMAGE.yml
@@ -31,6 +31,7 @@ jobs:
       - name: Install AWS CLI
         run: |
           sudo apt-get update
+          sudo apt-get uninstall awscli
           sudo apt-get install curl
           sudo apt-get install unzip
           sudo curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"

--- a/.github/workflows/BUILD-PRODUCTION-IMAGE.yml
+++ b/.github/workflows/BUILD-PRODUCTION-IMAGE.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Configure AWS credentials for production
         uses: aws-actions/configure-aws-credentials@v3

--- a/.github/workflows/BUILD-PRODUCTION-IMAGE.yml
+++ b/.github/workflows/BUILD-PRODUCTION-IMAGE.yml
@@ -31,12 +31,11 @@ jobs:
       - name: Install AWS CLI
         run: |
           sudo apt-get update
-          sudo apt-get uninstall awscli
           sudo apt-get install curl
           sudo apt-get install unzip
           sudo curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
           sudo unzip awscliv2.zip
-          sudo ./aws/install
+          sudo ./aws/install --update
 
       - name: Login to Amazon ECR
         id: login-ecr

--- a/.github/workflows/BUILD-PRODUCTION-IMAGE.yml
+++ b/.github/workflows/BUILD-PRODUCTION-IMAGE.yml
@@ -31,7 +31,11 @@ jobs:
       - name: Install AWS CLI
         run: |
           sudo apt-get update
-          sudo apt-get install -y awscli
+          sudo apt-get install curl
+          sudo apt-get install unzip
+          sudo curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+          sudo unzip awscliv2.zip
+          sudo ./aws/install
 
       - name: Login to Amazon ECR
         id: login-ecr

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17-slim-buster AS base
+FROM openjdk:17-slim AS base
 ENV JAR_FILE_NAME=backend-0.0.1-SNAPSHOT.jar
 ENV JAR_FILE_PATH=/home/deploy/app/backend/build/libs/${JAR_FILE_NAME}
 ENV TZ=Asia/Seoul

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17-slim AS base
+FROM openjdk:17-slim-bullseye AS base
 ENV JAR_FILE_NAME=backend-0.0.1-SNAPSHOT.jar
 ENV JAR_FILE_PATH=/home/deploy/app/backend/build/libs/${JAR_FILE_NAME}
 ENV TZ=Asia/Seoul

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17-slim-bullseye AS base
+FROM eclipse-temurin:17-jre-noble AS base
 ENV JAR_FILE_NAME=backend-0.0.1-SNAPSHOT.jar
 ENV JAR_FILE_PATH=/home/deploy/app/backend/build/libs/${JAR_FILE_NAME}
 ENV TZ=Asia/Seoul
@@ -8,7 +8,7 @@ FROM base as builder
 RUN apt-get -qq update > /dev/null && \
     DEBIAN_FRONTEND=noninteractive apt-get -yq --no-install-recommends install build-essential unzip procps curl > /dev/null
 
-RUN useradd --uid 1000 --gid users --shell /bin/bash --create-home deploy
+RUN useradd --gid users --shell /bin/bash --create-home deploy
 USER deploy
 
 RUN mkdir -p /home/deploy/app/backend

--- a/backend/src/main/java/org/algosolved/backend/core/config/SecurityConfig.java
+++ b/backend/src/main/java/org/algosolved/backend/core/config/SecurityConfig.java
@@ -57,7 +57,7 @@ public class SecurityConfig {
                         (exception) -> exception.authenticationEntryPoint(jwtAuthEntryPoint))
                 .sessionManagement(
                         (session) ->
-                                session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+                                session.sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED));
 
         return http.build();
     }

--- a/backend/src/main/java/org/algosolved/backend/core/config/SecurityConfig.java
+++ b/backend/src/main/java/org/algosolved/backend/core/config/SecurityConfig.java
@@ -1,8 +1,8 @@
 package org.algosolved.backend.core.config;
 
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+
 import org.algosolved.backend.core.filter.JwtAuthenticationFilter;
 import org.algosolved.backend.core.filter.OAuthSuccessHandler;
 import org.algosolved.backend.core.jwt.JwtAuthEntryPoint;
@@ -20,6 +20,8 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
+
+import java.util.List;
 
 @Slf4j
 @Configuration
@@ -46,8 +48,7 @@ public class SecurityConfig {
                                 cors.configurationSource(
                                         request -> {
                                             CorsConfiguration config = new CorsConfiguration();
-                                            config.setAllowedOrigins(
-                                                    List.of(CLIENT_ORIGIN));
+                                            config.setAllowedOrigins(List.of(CLIENT_ORIGIN));
                                             config.setAllowedMethods(
                                                     List.of("GET", "POST", "PUT", "DELETE"));
                                             config.setAllowedHeaders(

--- a/backend/src/main/java/org/algosolved/backend/core/config/SecurityConfig.java
+++ b/backend/src/main/java/org/algosolved/backend/core/config/SecurityConfig.java
@@ -82,6 +82,7 @@ public class SecurityConfig {
                                 "/api/swagger-ui.html",
                                 "/api/swagger-ui/**",
                                 "/api/v3/api-docs/**",
+                                "/api/login/oauth2/code/**",
                                 "/api/v1/user/auth/success")
                         .permitAll();
             }

--- a/backend/src/main/java/org/algosolved/backend/core/config/SecurityConfig.java
+++ b/backend/src/main/java/org/algosolved/backend/core/config/SecurityConfig.java
@@ -1,7 +1,7 @@
 package org.algosolved.backend.core.config;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
-
 import org.algosolved.backend.core.filter.JwtAuthenticationFilter;
 import org.algosolved.backend.core.filter.OAuthSuccessHandler;
 import org.algosolved.backend.core.jwt.JwtAuthEntryPoint;
@@ -18,8 +18,6 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
-
-import java.util.List;
 
 @Configuration
 @EnableWebSecurity
@@ -43,7 +41,7 @@ public class SecurityConfig {
                                         request -> {
                                             CorsConfiguration config = new CorsConfiguration();
                                             config.setAllowedOrigins(
-                                                    List.of("http://localhost:3000"));
+                                                    List.of("http://localhost:3000", "https://algosolved.org"));
                                             config.setAllowedMethods(
                                                     List.of("GET", "POST", "PUT", "DELETE"));
                                             config.setAllowedHeaders(

--- a/backend/src/main/java/org/algosolved/backend/core/config/SecurityConfig.java
+++ b/backend/src/main/java/org/algosolved/backend/core/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package org.algosolved.backend.core.config;
 
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.algosolved.backend.core.filter.JwtAuthenticationFilter;
 import org.algosolved.backend.core.filter.OAuthSuccessHandler;
 import org.algosolved.backend.core.jwt.JwtAuthEntryPoint;
@@ -19,6 +20,7 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
 
+@Slf4j
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
@@ -51,7 +53,12 @@ public class SecurityConfig {
                                         }))
                 .csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(setAuthRequiredPath())
-                .oauth2Login(oauth2 -> oauth2.successHandler(oAuthSuccessHandler))
+                .oauth2Login(oauth2 -> oauth2.successHandler(oAuthSuccessHandler)
+                        .failureHandler((request, response, exception) -> {
+                    log.error("❌ OAuth 인증 실패: " + exception.getMessage());
+                    exception.printStackTrace(); // 상세 로그 출력
+                    response.sendRedirect("/api/login?error=true");
+                }))
                 .addFilterBefore(jwtAuthTokenFilter, UsernamePasswordAuthenticationFilter.class)
                 .exceptionHandling(
                         (exception) -> exception.authenticationEntryPoint(jwtAuthEntryPoint))

--- a/backend/src/main/java/org/algosolved/backend/core/config/SecurityConfig.java
+++ b/backend/src/main/java/org/algosolved/backend/core/config/SecurityConfig.java
@@ -1,11 +1,12 @@
 package org.algosolved.backend.core.config;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-
 import org.algosolved.backend.core.filter.JwtAuthenticationFilter;
 import org.algosolved.backend.core.filter.OAuthSuccessHandler;
 import org.algosolved.backend.core.jwt.JwtAuthEntryPoint;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.Customizer;
@@ -20,8 +21,6 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
 
-import java.util.List;
-
 @Slf4j
 @Configuration
 @EnableWebSecurity
@@ -31,6 +30,9 @@ public class SecurityConfig {
     private final JwtAuthenticationFilter jwtAuthTokenFilter;
     private final JwtAuthEntryPoint jwtAuthEntryPoint;
     private final OAuthSuccessHandler oAuthSuccessHandler;
+
+    @Value("${client.base.url}")
+    private String CLIENT_ORIGIN;
 
     @Bean
     public PasswordEncoder passwordEncoder() {
@@ -45,9 +47,7 @@ public class SecurityConfig {
                                         request -> {
                                             CorsConfiguration config = new CorsConfiguration();
                                             config.setAllowedOrigins(
-                                                    List.of(
-                                                            "http://localhost:3000",
-                                                            "https://algosolved.org"));
+                                                    List.of(CLIENT_ORIGIN));
                                             config.setAllowedMethods(
                                                     List.of("GET", "POST", "PUT", "DELETE"));
                                             config.setAllowedHeaders(

--- a/backend/src/main/java/org/algosolved/backend/core/config/SecurityConfig.java
+++ b/backend/src/main/java/org/algosolved/backend/core/config/SecurityConfig.java
@@ -1,8 +1,8 @@
 package org.algosolved.backend.core.config;
 
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+
 import org.algosolved.backend.core.filter.JwtAuthenticationFilter;
 import org.algosolved.backend.core.filter.OAuthSuccessHandler;
 import org.algosolved.backend.core.jwt.JwtAuthEntryPoint;
@@ -19,6 +19,8 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
+
+import java.util.List;
 
 @Slf4j
 @Configuration
@@ -43,7 +45,9 @@ public class SecurityConfig {
                                         request -> {
                                             CorsConfiguration config = new CorsConfiguration();
                                             config.setAllowedOrigins(
-                                                    List.of("http://localhost:3000", "https://algosolved.org"));
+                                                    List.of(
+                                                            "http://localhost:3000",
+                                                            "https://algosolved.org"));
                                             config.setAllowedMethods(
                                                     List.of("GET", "POST", "PUT", "DELETE"));
                                             config.setAllowedHeaders(
@@ -53,18 +57,22 @@ public class SecurityConfig {
                                         }))
                 .csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(setAuthRequiredPath())
-                .oauth2Login(oauth2 -> oauth2.successHandler(oAuthSuccessHandler)
-                        .failureHandler((request, response, exception) -> {
-                    log.error("❌ OAuth 인증 실패: " + exception.getMessage());
-                    exception.printStackTrace(); // 상세 로그 출력
-                    response.sendRedirect("/api/login?error=true");
-                }))
+                .oauth2Login(
+                        oauth2 ->
+                                oauth2.successHandler(oAuthSuccessHandler)
+                                        .failureHandler(
+                                                (request, response, exception) -> {
+                                                    log.error(
+                                                            "❌ OAuth 인증 실패: "
+                                                                    + exception.getMessage());
+                                                    exception.printStackTrace(); // 상세 로그 출력
+                                                    response.sendRedirect("/api/login?error=true");
+                                                }))
                 .addFilterBefore(jwtAuthTokenFilter, UsernamePasswordAuthenticationFilter.class)
                 .exceptionHandling(
                         (exception) -> exception.authenticationEntryPoint(jwtAuthEntryPoint))
                 .sessionManagement(
-                        (session) ->
-                                session.sessionCreationPolicy(SessionCreationPolicy.ALWAYS));
+                        (session) -> session.sessionCreationPolicy(SessionCreationPolicy.ALWAYS));
 
         return http.build();
     }

--- a/backend/src/main/java/org/algosolved/backend/core/config/SecurityConfig.java
+++ b/backend/src/main/java/org/algosolved/backend/core/config/SecurityConfig.java
@@ -64,7 +64,7 @@ public class SecurityConfig {
                         (exception) -> exception.authenticationEntryPoint(jwtAuthEntryPoint))
                 .sessionManagement(
                         (session) ->
-                                session.sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED));
+                                session.sessionCreationPolicy(SessionCreationPolicy.ALWAYS));
 
         return http.build();
     }

--- a/backend/src/main/java/org/algosolved/backend/core/filter/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/org/algosolved/backend/core/filter/JwtAuthenticationFilter.java
@@ -1,16 +1,10 @@
 package org.algosolved.backend.core.filter;
 
 import io.jsonwebtoken.ExpiredJwtException;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import javax.servlet.FilterChain;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+
 import org.algosolved.backend.common.exceptions.JwtException;
 import org.algosolved.backend.core.jwt.JwtAuthProvider;
 import org.algosolved.backend.user.dto.UserJwtDto;
@@ -22,6 +16,16 @@ import org.springframework.security.web.authentication.WebAuthenticationDetailsS
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 import org.springframework.web.servlet.HandlerExceptionResolver;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
 @Slf4j
 @Component

--- a/backend/src/main/java/org/algosolved/backend/core/filter/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/org/algosolved/backend/core/filter/JwtAuthenticationFilter.java
@@ -1,10 +1,16 @@
 package org.algosolved.backend.core.filter;
 
 import io.jsonwebtoken.ExpiredJwtException;
-
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-
 import org.algosolved.backend.common.exceptions.JwtException;
 import org.algosolved.backend.core.jwt.JwtAuthProvider;
 import org.algosolved.backend.user.dto.UserJwtDto;
@@ -16,16 +22,6 @@ import org.springframework.security.web.authentication.WebAuthenticationDetailsS
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 import org.springframework.web.servlet.HandlerExceptionResolver;
-
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-
-import javax.servlet.FilterChain;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 
 @Slf4j
 @Component
@@ -45,7 +41,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         String method = request.getMethod();
         // 다음과 같은 uri는 토큰검증x
         String[] equalsWith = {
-            "/api/v1/health/ping",
+            "/api/health/ping",
             "/api/v1/users/signin",
             "/api/v1/users/refresh",
             "/api/oauth2/authorization/github",

--- a/backend/src/main/java/org/algosolved/backend/core/filter/OAuthSuccessHandler.java
+++ b/backend/src/main/java/org/algosolved/backend/core/filter/OAuthSuccessHandler.java
@@ -1,15 +1,18 @@
 package org.algosolved.backend.core.filter;
 
-import java.io.IOException;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
 @Slf4j
 @Component
@@ -27,6 +30,6 @@ public class OAuthSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
         String username = oAuth2User.getAttribute("login");
         request.getSession().setAttribute("oauthUserName", username);
 
-        response.sendRedirect(FRONTEND_ENDPOINT+ "/oauth");
+        response.sendRedirect(FRONTEND_ENDPOINT + "/oauth");
     }
 }

--- a/backend/src/main/java/org/algosolved/backend/core/filter/OAuthSuccessHandler.java
+++ b/backend/src/main/java/org/algosolved/backend/core/filter/OAuthSuccessHandler.java
@@ -1,17 +1,17 @@
 package org.algosolved.backend.core.filter;
 
+import java.io.IOException;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
 
-import java.io.IOException;
-
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
+@Slf4j
 @Component
 public class OAuthSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
@@ -23,6 +23,7 @@ public class OAuthSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
             HttpServletRequest request, HttpServletResponse response, Authentication authentication)
             throws IOException, ServletException {
         OAuth2User oAuth2User = (OAuth2User) authentication.getPrincipal();
+        log.info("OAuth2 attributes: " + oAuth2User.getAttributes());
         String username = oAuth2User.getAttribute("login");
         request.getSession().setAttribute("oauthUserName", username);
 

--- a/backend/src/main/java/org/algosolved/backend/core/filter/OAuthSuccessHandler.java
+++ b/backend/src/main/java/org/algosolved/backend/core/filter/OAuthSuccessHandler.java
@@ -26,6 +26,6 @@ public class OAuthSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
         String username = oAuth2User.getAttribute("login");
         request.getSession().setAttribute("oauthUserName", username);
 
-        response.sendRedirect(FRONTEND_ENDPOINT);
+        response.sendRedirect(FRONTEND_ENDPOINT+ "/login");
     }
 }

--- a/backend/src/main/java/org/algosolved/backend/core/filter/OAuthSuccessHandler.java
+++ b/backend/src/main/java/org/algosolved/backend/core/filter/OAuthSuccessHandler.java
@@ -26,6 +26,6 @@ public class OAuthSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
         String username = oAuth2User.getAttribute("login");
         request.getSession().setAttribute("oauthUserName", username);
 
-        response.sendRedirect(FRONTEND_ENDPOINT+ "/login");
+        response.sendRedirect(FRONTEND_ENDPOINT+ "/oauth");
     }
 }

--- a/backend/src/main/resources/application-prod.properties
+++ b/backend/src/main/resources/application-prod.properties
@@ -12,4 +12,6 @@ spring.jpa.properties.hibernate.format_sql=true
 client.base.url=https://algosolved.org
 spring.security.oauth2.client.registration.github.redirect-uri=https://algosolved.org/api/login/oauth2/code/github
 
-
+#cookie
+server.servlet.session.cookie.secure: true
+server.servlet.session.cookie.same-site: none

--- a/backend/src/main/resources/application-prod.properties
+++ b/backend/src/main/resources/application-prod.properties
@@ -10,4 +10,6 @@ spring.jpa.properties.hibernate.format_sql=true
 
 # cilent
 client.base.url=https://algosolved.org
+spring.security.oauth2.client.registration.github.redirect-uri=https://algosolved.org/api/login/oauth2/code/github
+
 

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,48 +1,26 @@
-.App {
-  text-align: center;
-  height: auto;
-  min-height: 100%;
-  padding-bottom: 10rem;
+
+html, body, #root {
+  height: 100%;
+  margin: 0;
+  padding: 0;
 }
 
-.App-logo {
-  height: 40vmin;
-  pointer-events: none;
+.app-wrapper {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+.app-content {
+  flex: 1;
 }
 
 .footer {
-  text-align: center;
-  height: 10rem;
-  position: relative;
-  transform: translateY(-100%);
-}
-
-@media (prefers-reduced-motion: no-preference) {
-  .App-logo {
-    animation: App-logo-spin infinite 20s linear;
-  }
-}
-
-.App-header {
-  background-color: #282c34;
-  min-height: 100%;
+  height: 10vh;
+  background-color: #EEEEEE;
+  color: white;
   display: flex;
-  flex-direction: column;
   align-items: center;
   justify-content: center;
-  font-size: calc(10px + 2vmin);
-  color: white;
 }
 
-.App-link {
-  color: #61dafb;
-}
-
-@keyframes App-logo-spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
-}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,20 +1,31 @@
 import React from "react";
+import { BrowserRouter, Routes, Route } from "react-router-dom";
+
+import { Container, List, ListItem, ListItemText, ListItemIcon } from "@mui/material";
 
 import "./App.css";
 import Footer from "./components/common/Footer";
+import NavBar from "./components/common/Nav";
 import Seo from "./components/common/Seo";
 import Router from "./routers/router";
 
 function App() {
   return (
   <>
-    <div className="App">
+    <BrowserRouter>
+    <div className="app-wrapper">
       <Seo />
-      <Router />
+      <NavBar />
+      <div className="app-content">
+      <Container>
+        <Router />
+      </Container>
+      </div>
+      <footer className="footer">
+        <Footer />
+      </footer>
     </div>
-    <div className="footer">
-      <Footer />
-    </div>
+    </BrowserRouter>
   </>
   );
 }

--- a/frontend/src/components/common/Banner.tsx
+++ b/frontend/src/components/common/Banner.tsx
@@ -10,7 +10,6 @@ const Banner = () => {
         <div style={{ height: '100%', maxHeight: '500px'}}>
             <h2>AlgoSolved!</h2>
         </div>
-
     );
 }
 

--- a/frontend/src/components/common/Footer.tsx
+++ b/frontend/src/components/common/Footer.tsx
@@ -25,21 +25,11 @@ const defaultTheme = createTheme();
 function Footer() {
   return (
     <ThemeProvider theme={defaultTheme}>
-      <Box
-        sx={{
-          display: "flex",
-          flexDirection: "column",
-          minHeight: "25vh",
-        }}
-      >
-        <CssBaseline />
-
         <Box
           component="footer"
           sx={{
             py: 3,
             px: 2,
-            mt: "auto",
             backgroundColor: (theme) =>
               theme.palette.mode === "light"
                 ? theme.palette.grey[200]
@@ -50,7 +40,6 @@ function Footer() {
             <Copyright />
           </Container>
         </Box>
-      </Box>
     </ThemeProvider>
   );
 }

--- a/frontend/src/components/common/Nav.tsx
+++ b/frontend/src/components/common/Nav.tsx
@@ -108,9 +108,9 @@ function NavBar() {
                       variant="contained"
                       aria-label="Disabled elevation buttons"
                     >
-                    <Link to={process.env.REACT_APP_API_BASE_URL+'/api/oauth2/authorization/github'}>
+                    <a href={process.env.REACT_APP_API_BASE_URL+'/api/oauth2/authorization/github'}>
                       <Button>Login</Button>
-                    </Link>
+                    </a>
                     </ButtonGroup>
                 }
                 </Box>

--- a/frontend/src/components/common/Nav.tsx
+++ b/frontend/src/components/common/Nav.tsx
@@ -64,7 +64,7 @@ const Logo = styled(Link)(({theme}) => ({
 const isLoggedIn = false;
 
 
-function NavBar() {
+export const NavBar = () => {
 
   // TODO: 서버의 세션 정보를 클라이언트에 저장해야함.
   const handleLogin = () => {
@@ -72,8 +72,9 @@ function NavBar() {
   };
 
   return (
-    <Container>
-        <AppBar position="static">
+
+        <AppBar position="static" sx={{ backgroundColor: "#0D1117", color: "#ffffff" }}>
+        <Container>
             <Toolbar>
                 <Logo to={'/'} >
                     Algo Solved
@@ -115,9 +116,8 @@ function NavBar() {
                 }
                 </Box>
             </Toolbar>
+            </Container>
         </AppBar>
-        <br/>
-    </Container>
    );
 }
 

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,18 +1,20 @@
 import React from "react";
 
 import Banner from "../components/common/Banner";
-import NavBar from "../components/common/Nav";
 import SolutionList from "../components/home/SolutionList";
 import { useSolutionList } from "../hooks/solutionList";
 import style from "../styles/pages/Home.module.css";
 
+import { Container } from "@mui/material";
+
 const Home = () => {
   return (
-    <div className={style.wrapper}>
-      <NavBar />
-      <Banner />
-      <SolutionList list={useSolutionList()} />
-    </div>
+      <Container>
+        <div className={style.wrapper}>
+          <Banner />
+          <SolutionList list={useSolutionList()} />
+        </div>
+      </Container>
   );
 };
 

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -1,21 +1,22 @@
 import React from "react";
 
 import Banner from "../components/common/Banner";
-import NavBar from "../components/common/Nav";
 import CircularProgress from '@mui/material/CircularProgress';
 import { useLogin } from "../hooks/login";
 import style from "../styles/pages/Home.module.css";
 
+import { Container } from "@mui/material";
 
 const Login = () => {
   const data = useLogin();
 
   return (
-    <div className={style.wrapper}>
-      <NavBar />
-      <CircularProgress />
-      <div>깃허브 정보를 가져오는 중입니다..</div>
-    </div>
+    <Container>
+      <div className={style.wrapper}>
+        <CircularProgress />
+        <div>깃허브 정보를 가져오는 중입니다..</div>
+      </div>
+    </Container>
   );
 };
 

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -5,18 +5,31 @@ import CircularProgress from '@mui/material/CircularProgress';
 import { useLogin } from "../hooks/login";
 import style from "../styles/pages/Home.module.css";
 
-import { Container } from "@mui/material";
+import { Card, CardContent, Box, Typography } from "@mui/material";
 
 const Login = () => {
   const data = useLogin();
 
   return (
-    <Container>
-      <div className={style.wrapper}>
-        <CircularProgress />
-        <div>깃허브 정보를 가져오는 중입니다..</div>
-      </div>
-    </Container>
+    <Card sx={{ margin: '2%', minHeight: '500px', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+      <CardContent>
+        <Box
+          sx={{
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            justifyContent: 'center',
+            height: '100%',
+            textAlign: 'center',
+          }}
+        >
+          <Typography variant="h6" gutterBottom>
+            깃허브 정보를 가져오는 중입니다..
+          </Typography>
+          <CircularProgress />
+        </Box>
+      </CardContent>
+    </Card>
   );
 };
 

--- a/frontend/src/pages/SolutionDetail.tsx
+++ b/frontend/src/pages/SolutionDetail.tsx
@@ -2,21 +2,21 @@ import React from "react";
 import { useParams } from 'react-router';
 
 import Banner from "../components/common/Banner";
-import NavBar from "../components/common/Nav";
 import Detail from "../components/solutions/Detail";
 
 import { useSolutionDetail } from "../hooks/solutionDetail";
-
+import { Container } from "@mui/material";
 
 const SolutionDetail = () => {
 
   const { id } = useParams();
 
   return (
+  <Container>
     <div>
-      <NavBar />
       <Detail solution={ useSolutionDetail(Number(id))} />
     </div>
+  </Container>
   );
 };
 

--- a/frontend/src/pages/UserInfo.tsx
+++ b/frontend/src/pages/UserInfo.tsx
@@ -1,19 +1,21 @@
 import React from "react";
 
-import NavBar from "../components/common/Nav";
 import AccountInfo from "../components/users/Info";
 import Repository from "../components/users/Repository";
 import { useUserInfo } from "../hooks/userInfo";
 import style from "../styles/pages/Home.module.css";
 
+import { Container } from "@mui/material";
+
 // TODO: userUserInfo 에 현재 로그인 한 사용자의 id를 넣도록 수정
 const UserInfo = () => {
   return (
+    <Container>
     <div className={style.wrapper}>
-      <NavBar />
       <AccountInfo user={useUserInfo(1)} />
       <Repository />
     </div>
+    </Container>
   );
 };
 

--- a/frontend/src/pages/common/NotFoundPage.tsx
+++ b/frontend/src/pages/common/NotFoundPage.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { Box, Typography, Button } from '@mui/material';
+import { useNavigate } from 'react-router-dom';
+
+const NotFoundPage = () => {
+const navigate = useNavigate();
+
+return (
+<Box
+    display="flex"
+    flexDirection="column"
+    justifyContent="center"
+    alignItems="center"
+    height="100vh"
+    textAlign="center"
+    px={2}
+>
+  <Typography variant="h1" color="primary" gutterBottom>
+    404
+  </Typography>
+  <Typography variant="h5" gutterBottom>
+    페이지를 찾을 수 없습니다.
+  </Typography>
+  <Typography variant="body1" mb={4}>
+    존재하지 않는 경로이거나, 주소가 잘못되었습니다.
+  </Typography>
+  <Button variant="contained" color="primary" onClick={() => navigate('/')}>
+  홈으로 이동
+  </Button>
+</Box>
+);
+};
+
+export default NotFoundPage;

--- a/frontend/src/routers/router.tsx
+++ b/frontend/src/routers/router.tsx
@@ -14,7 +14,7 @@ const Router = () => {
         <Route path="/" element={<Home />} />
         <Route path="/users" element={<Users />} />
         <Route path="/problem/detail/:id" element={<SolutionDetail />} />
-        <Route path="/login" element={<Login />} />
+        <Route path="/oauth" element={<Login />} />
 
         <Route path="*" element={<NotFoundPage />} />
       </Routes>

--- a/frontend/src/routers/router.tsx
+++ b/frontend/src/routers/router.tsx
@@ -7,9 +7,10 @@ import Login from "../pages/Login";
 import NotFoundPage from "../pages/common/NotFoundPage";
 import SolutionDetail from "../pages/SolutionDetail";
 
+
 const Router = () => {
   return (
-    <BrowserRouter>
+
       <Routes>
         <Route path="/" element={<Home />} />
         <Route path="/users" element={<Users />} />
@@ -18,7 +19,7 @@ const Router = () => {
 
         <Route path="*" element={<NotFoundPage />} />
       </Routes>
-    </BrowserRouter>
+
   );
 };
 

--- a/frontend/src/routers/router.tsx
+++ b/frontend/src/routers/router.tsx
@@ -4,6 +4,7 @@ import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Home from "../pages/Home";
 import Users from "../pages/UserInfo";
 import Login from "../pages/Login";
+import NotFoundPage from "../pages/common/NotFoundPage";
 import SolutionDetail from "../pages/SolutionDetail";
 
 const Router = () => {
@@ -14,6 +15,8 @@ const Router = () => {
         <Route path="/users" element={<Users />} />
         <Route path="/problem/detail/:id" element={<SolutionDetail />} />
         <Route path="/login" element={<Login />} />
+
+        <Route path="*" element={<NotFoundPage />} />
       </Routes>
     </BrowserRouter>
   );


### PR DESCRIPTION
## 작업 내용

**백엔드**
- 배포 및 관련 액션 라이브러리의 버전 업하여 배포가 가능하도록 수정한다.
- 상용 환경에 Github 소셜로그인 과정에서 리다이렉션 설정 및 쿠키 설정, 로깅을 추가한다.
- TODO: github 소셜 로그인 이후 유저를 추가하는 부분이 없어 추후 추가 필요.

**프론트**
- NavBar 및 페이지 기본 Component 구성 수정
  - Page.tsx 에서 Container 선언을 하는 대신, 기본 App 레이아웃, Router 선언단에서 Container 를 선언하여, NavBar 및 기본 레이아웃에 맞는 페이지 구성이 되도록 통일
- Footer가 하단에 고정되도록 수정, 소셜로그인 연동 프로그래스 페이지 - 리 디자인
- 404 페이지 추가


## 이슈
- Deprecated 된 라이브러리 버전으로 배포를 못하는 이슈가 있음.
- 상용 환경의 소셜로그인 동작과정에서 리다이렉트가 정상적이지 못한 이슈가 있음.

### 이미지
- 변경된 레이아웃에 따른 페이지
<img width="1470" height="707" alt="SCR-20250820-jlhf" src="https://github.com/user-attachments/assets/8a134e09-6b4b-44fa-bc08-8064ab238188" />

- 404 페이지 
<img width="1320" height="693" alt="SCR-20250820-jluj" src="https://github.com/user-attachments/assets/9c1ac1bd-0da6-4387-908e-f663d137ea86" />

- 깃허브 액션 수정 후 

<img width="1112" height="419" alt="SCR-20250820-jmdx" src="https://github.com/user-attachments/assets/ec2f5adf-af92-4c27-8761-27f5eeab300a" />

